### PR TITLE
IO plugin restructure

### DIFF
--- a/lumispy/__init__.py
+++ b/lumispy/__init__.py
@@ -47,7 +47,7 @@ from .signals.pl_spectrum import LazyPLSpectrum
 from .signals.el_spectrum import LazyELSpectrum
 from .signals.luminescence_transient import LazyLumiTransient
 
-from .utils.io_utils import load_hypcard
+from .io import load
 
 from . import release_info
 
@@ -61,3 +61,4 @@ __email__ = release_info.email
 __status__ = release_info.status
 
 _logger = logging.getLogger(__name__)
+

--- a/lumispy/io.py
+++ b/lumispy/io.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import hyperspy.io
+# To keep the unmodified version of `load_single_files` from hyperspy before modification
+from hyperspy.io import load_single_file as hyperspy_load_single_file
+from lumispy.io_plugins import io_plugins
+
+
+def load_single_file(filename, **kwds):
+    """
+    Modified version of `load_single_file()` of Hyperspy.
+    It also supports HYPScan.bin files (from Attolight).
+
+    Parameters
+    ----------
+
+    filename : string
+        File name (including the extension)
+
+    """
+    extension = os.path.splitext(filename)[1][1:]
+
+    for i in range(len(io_plugins)):
+        if extension.lower() in io_plugins[i].file_extensions:
+            reader = io_plugins[i]
+            # Maybe this needs to be changed...
+            lumispy_object = reader.file_reader(filename, **kwds)
+            return lumispy_object
+
+    # Load with the Hyperspy function
+    return hyperspy_load_single_file(filename, **kwds)
+
+
+# Monkey patch function (updating it from hyperspy's default function)
+hyperspy.io.load_single_file = load_single_file
+
+load = hyperspy.io.load

--- a/lumispy/io_plugins/README
+++ b/lumispy/io_plugins/README
@@ -1,0 +1,32 @@
+Definition of a read/write plugin
+---------------------------------
+
+All the read/write plugins must provide a python file containing:
+
+    - The characteristics of the IO plugin as the following python variables:
+
+        # Plugin characteristics
+        # ----------------------
+	format_name = <String>
+        description = <String>
+        full_support = <Bool>	# Whether all the Lumispy features are supported
+        # Recognised file extension
+        file_extensions = <Tuple of string>
+        default_extension = <Int>	# Index of the extension that will be used by default
+        # Reading capabilities
+        reads_images = <Bool>
+        reads_spectrum = <Bool>
+        reads_spectrum_image = <Bool>
+        # Writing capabilities
+        writes_images = <Bool>
+        writes_spectrum = <Bool>
+        writes_spectrum_image = <Bool>
+
+    - A function called file_reader with at least one attribute: filename.
+    It must return a lumispy object (from the lumispy.signals classes)
+
+    if writes = True:
+    - A function called file_writer with at least two attributes: 
+        filename and object2save in that order.
+
+They must also be declared in io.py

--- a/lumispy/io_plugins/__init__.py
+++ b/lumispy/io_plugins/__init__.py
@@ -16,14 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-acquisition_systems = {
-    'cambridge_attolight' : {
-        'channels' : 1024,
-        'cal_factor_x_axis' : 131072,
-        'metadata_file_name' :'MicroscopeStatus.txt',
-        'grating_corrfactors' : {
-            150 : 2.73E-04,
-            600 : 6.693659836087227e-05,
-        }
-    }
-}
+from lumispy.io_plugins import attolight
+
+io_plugins = [attolight]
+
+default_write_ext = set()
+for plugin in io_plugins:
+    if plugin.writes:
+        default_write_ext.add(
+            plugin.file_extensions[plugin.default_extension])

--- a/lumispy/io_plugins/attolight.py
+++ b/lumispy/io_plugins/attolight.py
@@ -15,33 +15,46 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
-
-# a lot of stuff depends on this, so we have to create it first
-
 import glob
-import logging
 import os
-import warnings
 import numpy as np
-
-#from hyperspy.io import load as hyperspyload
-#from hyperspy.io import load_with_reader
-
-from hyperspy.signals import Signal2D
+from hyperspy._signals.signal2d import Signal2D
 from lumispy.signals.cl_sem_spectrum import CLSEMSpectrum
 
-from .acquisition_systems import acquisition_systems
+# Plugin characteristics
+# ----------------------
+format_name = 'AttolightSEM_HYPCard'
+description = 'Reads CL data from the Attolight SEM system'
+version = '0.1'
+full_support = False
+# Recognised file extension
+file_extensions = ['bin', 'BIN']
+default_extension = 0
+# Writing capabilities
+writes = False
+
+# Attolight system specific parameters
+# ------------------------------------
+attolight_systems = {
+    'cambridge_uk_attolight': {
+        'channels': 1024,
+        'cal_factor_x_axis': 131072,
+        'metadata_file_name': 'MicroscopeStatus.txt',
+        'grating_corrfactors': {
+            150: 2.73E-04,
+            600: 6.693659836087227e-05,
+        }
+    }
+}
 
 
-
-
-def load_hypcard(hypcard_file_path=None, lazy = False, acquisition_system
-                 = 'cambridge_attolight'):
-    """Load data into pyxem objects.
+def file_reader(filename, *args, **kwds):
+    """Load data into CLSEMSpectrum lumispy object.
     Parameters
     ----------
-    hypcard_file_path : str, None
-        The HYPCard.bin filepath for the file to be loaded, created by AttoLight software. Please, state the directory.
+    filename : str, None
+        The HYPCard.bin filepath for the file to be loaded, created by AttoLight software.
+        Please, state the directory.
         If None, a pop-up window will be loaded.
     lazy : bool
         If True the file will be opened lazily, i.e. without actually reading
@@ -50,63 +63,69 @@ def load_hypcard(hypcard_file_path=None, lazy = False, acquisition_system
     metadata_file_name: str
         By default, AttoLight software names it 'MicroscopeStatus.txt'.
         Otherwise, specify.
-    acquisition_system : str
+    attolight_acquisition_system : str
         Specify which acquisition system the HYPCard was taken with, from the
-        acquisition_systems.py dictionary file. By default, it assumes it is
+        attolight_systems dictionary file. By default, it assumes it is
         the Cambridge Attolight SEM system.
     Returns
     -------
     s : Signal
-        A pyxem Signal object containing loaded data.
+        A CLSEMSpectrum lumispy object containing loaded data.
     """
-    def get_metadata(hypcard_folder, metadata_file_name):
+    # Read the kwds, else return their default
+    lazy = kwds.pop('lazy', False)
+    attolight_acquisition_system = kwds.pop('attolight_acquisition_system', 'cambridge_uk_attolight')
+    metadata_file_name = kwds.pop('metadata_file_name',
+                                  attolight_systems[attolight_acquisition_system]['metadata_file_name'])
+
+    def _get_metadata(filename, md_file_name, attolight_acquisition_system):
         """Import the metadata from the MicroscopeStatus.txt file.
         Returns binning, nx, ny, FOV, grating and central_wavelength.
         Parameters
         ----------
-        hypcard_folder : str
-            The absolute folder path where the metadata_file_name exists.
+        filename : str
+            The absolute folder path where the md_file_name exists.
         """
-        path = os.path.join(hypcard_folder, metadata_file_name)
-        with open(path, encoding='windows-1252' ) as status:
+        path = os.path.join(filename, md_file_name)
+        with open(path, encoding='windows-1252') as status:
             for line in status:
                 if 'Horizontal Binning:' in line:
-                    binning = int(line[line.find(':')+1:-1])        #binning = binning status
+                    binning = int(line[line.find(':') + 1:-1])  # binning = binning status
                 if 'Resolution_X' in line:
-                    nx = int(line[line.find(':')+1:-7])
-                    #nx = pixel in x-direction
+                    nx = int(line[line.find(':') + 1:-7])
+                    # nx = pixel in x-direction
                 if 'Resolution_Y' in line:
-                    ny = int(line[line.find(':')+1:-7])
-                    #ny = pixel in y-direction
+                    ny = int(line[line.find(':') + 1:-7])
+                    # ny = pixel in y-direction
                 if 'Real Magnification' in line:
-                     FOV = float(line[line.find(':')+1:-1])
+                    FOV = float(line[line.find(':') + 1:-1])
                 if 'Grating - Groove Density:' in line:
-                    grating = float(line[line.find(':')+1:-6])
+                    grating = float(line[line.find(':') + 1:-6])
                 if 'Central wavelength:' in line:
-                    central_wavelength_nm = float(line[line.find(':')+1:-4])
+                    central_wavelength_nm = float(line[line.find(':') + 1:-4])
                 if 'Channels:' in line:
-                    total_channels = int(line[line.find(':')+1:-1])
+                    total_channels = int(line[line.find(':') + 1:-1])
                 if 'Signal Amplification:' in line:
-                    amplification = int(line[line.find(':x')+2:-1])
+                    amplification = int(line[line.find(':x') + 2:-1])
                 if 'Readout Rate (horizontal pixel shift):' in line:
-                    readout_rate_khz = int(line[line.find(':')+1:-4])
+                    readout_rate_khz = int(line[line.find(':') + 1:-4])
 
                 if 'Exposure Time:' in line:
-                    exposure_time_ccd_s = float(line[line.find(':')+1:-3])
+                    exposure_time_ccd_s = float(line[line.find(':') + 1:-3])
                 if 'HYP Dwelltime:' in line:
-                    dwell_time_scan_s = float(line[line.find(':')+1:-4])/1000
+                    dwell_time_scan_s = float(line[line.find(':') + 1:-4]) / 1000
                 if 'Beam Energy:' in line:
-                    beam_acc_voltage_kv = float(line[line.find(':')+1:-3])/1000
+                    beam_acc_voltage_kv = float(line[line.find(':') + 1:-3]) / 1000
                 if 'Gun Lens:' in line:
-                    gun_lens_amps = float(line[line.find(':')+1:-3])
+                    gun_lens_amps = float(line[line.find(':') + 1:-3])
                 if 'Objective Lens:' in line:
-                    obj_lens_amps = float(line[line.find(':')+1:-3])
+                    obj_lens_amps = float(line[line.find(':') + 1:-3])
                 if 'Aperture:' in line:
-                    aperture_um = float(line[line.find(':')+1:-4])
+                    aperture_um = float(line[line.find(':') + 1:-4])
                 if 'Aperture Chamber Pressure:' in line:
-                    chamber_pressure_torr = float(line[line.find(':')+1:-6])
+                    chamber_pressure_torr = float(line[line.find(':') + 1:-6])
                 if 'Real Magnification:' in line:
-                    real_magnification = float(line[line.find(':')+1:-3])
+                    real_magnification = float(line[line.find(':') + 1:-3])
 
         # Correct channels to the actual value, accounting for binning. Get
         # channels on the detector used (if channels not defined, then assume
@@ -114,14 +133,14 @@ def load_hypcard(hypcard_file_path=None, lazy = False, acquisition_system
         try:
             total_channels
         except:
-            total_channels = acquisition_systems[acquisition_system]['channels']
-        channels =  total_channels//binning
+            total_channels = attolight_systems[attolight_acquisition_system]['channels']
+        channels = total_channels // binning
 
-        #Return metadata
-        return binning, nx, ny, FOV, grating, central_wavelength_nm, channels, amplification, readout_rate_khz, exposure_time_ccd_s,  dwell_time_scan_s, beam_acc_voltage_kv, gun_lens_amps, obj_lens_amps, aperture_um, chamber_pressure_torr, real_magnification
+        # Return metadata
+        return binning, nx, ny, FOV, grating, central_wavelength_nm, channels, amplification, readout_rate_khz, exposure_time_ccd_s, dwell_time_scan_s, beam_acc_voltage_kv, gun_lens_amps, obj_lens_amps, aperture_um, chamber_pressure_torr, real_magnification
 
-    def store_metadata(cl_object, hypcard_folder, metadata_file_name,
-                       acquisition_system):
+    def _store_metadata(cl_object, hypcard_folder, md_file_name,
+                       attolight_acquisition_system):
         """
         TO BE ADDED
         Store metadata in the CLSpectrum object metadata property. Stores
@@ -133,10 +152,11 @@ def load_hypcard(hypcard_file_path=None, lazy = False, acquisition_system
         hypcard_folder : str
             The absolute folder path where the metadata_file_name exists.
         """
-        #Get metadata
-        binning, nx, ny, FOV, grating, central_wavelength_nm, channels, amplification, readout_rate_khz, exposure_time_ccd_s, dwell_time_scan_s, beam_acc_voltage_kv, gun_lens_amps, obj_lens_amps, aperture_um, chamber_pressure_torr, real_magnification = get_metadata(hypcard_folder, metadata_file_name)
+        # Get metadata
+        binning, nx, ny, FOV, grating, central_wavelength_nm, channels, amplification, readout_rate_khz, exposure_time_ccd_s, dwell_time_scan_s, beam_acc_voltage_kv, gun_lens_amps, obj_lens_amps, aperture_um, chamber_pressure_torr, real_magnification = _get_metadata(
+            hypcard_folder, md_file_name, attolight_acquisition_system)
 
-        #Store metadata
+        # Store metadata
         cl_object.metadata.set_item("Acquisition_instrument.Spectrometer.grating",
                                     grating)
         cl_object.metadata.set_item("Acquisition_instrument.Spectrometer.central_wavelength_nm",
@@ -151,8 +171,8 @@ def load_hypcard(hypcard_file_path=None, lazy = False, acquisition_system
         cl_object.metadata.set_item("Acquisition_instrument.CCD.channels",
                                     channels)
         cl_object.metadata.set_item("Acquisition_instrument.acquisition_system",
-                                    acquisition_system)
-        cl_object.metadata.set_item("Acquisition_instrument.CCD.amplification",amplification)
+                                    attolight_acquisition_system)
+        cl_object.metadata.set_item("Acquisition_instrument.CCD.amplification", amplification)
         cl_object.metadata.set_item("Acquisition_instrument.CCD.readout_rate_khz", readout_rate_khz)
         cl_object.metadata.set_item("Acquisition_instrument.CCD.exposure_time_s", exposure_time_ccd_s)
         cl_object.metadata.set_item("Acquisition_instrument.SEM.dwell_time_scan_s", dwell_time_scan_s)
@@ -166,7 +186,7 @@ def load_hypcard(hypcard_file_path=None, lazy = False, acquisition_system
 
         return cl_object
 
-    def calibrate_signal_axis_wavelength(cl_object):
+    def _calibrate_signal_axis_wavelength(cl_object):
         """
         Based on the Attolight software export function. Need to be automatised.
         Two calibrated sets show the trend:
@@ -180,23 +200,23 @@ def load_hypcard(hypcard_file_path=None, lazy = False, acquisition_system
             Array containing the spectrum energy axis start and end points in
             nm (from the MeanSpectrum file), such as [spec_start, spec_end]
         """
-        #Get relevant parameters from metadata
+        # Get relevant parameters from metadata
         central_wavelength = cl_object.metadata.Acquisition_instrument.Spectrometer.central_wavelength_nm
 
-        #Estimate start and end wavelengths
-        spectra_offset_array = [central_wavelength-273, central_wavelength+273]
+        # Estimate start and end wavelengths
+        spectra_offset_array = [central_wavelength - 273, central_wavelength + 273]
 
-        #Apply calibration
+        # Apply calibration
         dx = cl_object.axes_manager.signal_axes[0]
         dx.name = 'Wavelength'
         dx.scale = (spectra_offset_array[1] - spectra_offset_array[0]) \
-                                / cl_object.axes_manager.signal_size
+                   / cl_object.axes_manager.signal_size
         dx.offset = spectra_offset_array[0]
         dx.units = '$nm$'
 
         return cl_object
 
-    def calibrate_navigation_axis(cl_object):
+    def _calibrate_navigation_axis(cl_object):
         # Edit the navigation axes
         x = cl_object.axes_manager.navigation_axes[0]
         y = cl_object.axes_manager.navigation_axes[1]
@@ -206,25 +226,25 @@ def load_hypcard(hypcard_file_path=None, lazy = False, acquisition_system
         acquisition_system \
             = cl_object.metadata.Acquisition_instrument.acquisition_system
         cal_factor_x_axis \
-            = acquisition_systems[acquisition_system]['cal_factor_x_axis']
+            = attolight_systems[attolight_acquisition_system]['cal_factor_x_axis']
         FOV = cl_object.metadata.Acquisition_instrument.SEM.FOV
         nx = cl_object.metadata.Acquisition_instrument.SEM.resolution_x
 
         # Get the calibrated scanning axis scale from the acquisition_systems
         # dictionary
-        calax = cal_factor_x_axis/(FOV*nx)
+        calax = cal_factor_x_axis / (FOV * nx)
         x.name = 'x'
         x.scale = calax * 1000
-        #changes micrometer to nm, value for the size of 1 pixel
+        # changes micrometer to nm, value for the size of 1 pixel
         x.units = 'nm'
         y.name = 'y'
         y.scale = calax * 1000
-        #changes micrometer to nm, value for the size of 1 pixel
+        # changes micrometer to nm, value for the size of 1 pixel
         y.units = 'nm'
 
         return cl_object
 
-    def save_background(cl_object, hypcard_folder, background_file_name='Background*.txt'):
+    def _save_background(cl_object, hypcard_folder, background_file_name='Background*.txt'):
         """
         Based on the Attolight background savefunction.
         If background is found in the folder, it saves background as a cl_object.background attribute.
@@ -234,92 +254,94 @@ def load_hypcard(hypcard_file_path=None, lazy = False, acquisition_system
         cl_object:
             With the background saved as a background attribute.
         """
-        #Get the absolute path
+        # Get the absolute path
         path = os.path.join(hypcard_folder, background_file_name)
-        #Try to load the file, if it exists.
+        # Try to load the file, if it exists.
         try:
-            #Find the exact filename, using the * wildcard
+            # Find the exact filename, using the * wildcard
             path = glob.glob(path)[0]
-            #Load the file as a numpy array
+            # Load the file as a numpy array
             bkg = np.loadtxt(path)
-            #Extract only the  signal axis
-            #ERROR from AttoLight bug
+            # Extract only the  signal axis
+            # ERROR from AttoLight bug
             bkg = bkg[1]
-            #Retrieve the correct x axis from the cl_object
-            #ERROR from AttoLight bug
+            # Retrieve the correct x axis from the cl_object
+            # ERROR from AttoLight bug
             x_axis = cl_object.axes_manager.signal_axes[0].axis
-            #Join x axis with bkg signal
+            # Join x axis with bkg signal
             background = [x_axis, bkg]
-            #Store the value as background attribute
+            # Store the value as background attribute
             cl_object.background = background
             return cl_object
 
-        #If file does not exist, return function
+        # If file does not exist, return function
         except:
             return
 
-
     #################################
 
-    #Loading function starts here
+    # Loading function starts here
 
-    #Check if a path has been given
-    if hypcard_file_path is None:
+    # Check if a path has been given
+    if filename is None:
         from hyperspy.signal_tools import Load
         from hyperspy.ui_registry import get_gui
         load_ui = Load()
         get_gui(load_ui, toolkey="hyperspy.load")
         if load_ui.filename:
-            hypcard_file_path = load_ui.filename
+            filename = load_ui.filename
             lazy = load_ui.lazy
-        if hypcard_file_path is None:
+        if filename is None:
             raise ValueError("No file provided to reader")
 
-    #Import folder name
-    hypcard_folder = os.path.split(os.path.abspath(hypcard_file_path))[0]
+    # Import folder name
+    hypcard_folder = os.path.split(os.path.abspath(filename))[0]
 
-    #Import metadata
+    # Import metadata
     metadata_file_name \
-                = acquisition_systems[acquisition_system]['metadata_file_name']
+        = attolight_systems[attolight_acquisition_system]['metadata_file_name']
 
-    binning, nx, ny, FOV, grating, central_wavelength_nm, channels, amplification, readout_rate_khz, exposure_time_ccd_s, dwell_time_scan_s, beam_acc_voltage_kv, gun_lens_amps, obj_lens_amps, aperture_um, chamber_pressure_torr, real_magnification = get_metadata(hypcard_folder, metadata_file_name)
+    binning, nx, ny, FOV, grating, central_wavelength_nm, channels, amplification, readout_rate_khz, \
+    exposure_time_ccd_s, dwell_time_scan_s, beam_acc_voltage_kv, gun_lens_amps, obj_lens_amps, aperture_um,\
+    chamber_pressure_torr, real_magnification = \
+        _get_metadata(hypcard_folder, metadata_file_name, attolight_acquisition_system)
 
-
-    #Load file
-    with open(hypcard_file_path, 'rb') as f:
-        data = np.fromfile(f, dtype= [('bar', '<i4')], count= channels*nx*ny)
+    # Load file
+    with open(filename, 'rb') as f:
+        data = np.fromfile(f, dtype=[('bar', '<i4')], count=channels * nx * ny)
         array = np.reshape(data, [channels, nx, ny], order='F')
 
-    #Swap x-y axes to get the right xy orientation
-    sarray = np.swapaxes(array, 1,2)
+    # Swap x-y axes to get the right xy orientation
+    sarray = np.swapaxes(array, 1, 2)
 
-    ##Make the CLSEMSpectrum object
-    #Load the transposed data
+    # Make the CLSEMSpectrum object
+    # Load the transposed data
     s = Signal2D(sarray).T
     s.change_dtype('float')
     s = CLSEMSpectrum(s)
 
-    #Add all parameters as metadata
-    store_metadata(s, hypcard_folder, metadata_file_name, acquisition_system)
+    # Add all parameters as metadata
+    _store_metadata(s, hypcard_folder, metadata_file_name, attolight_acquisition_system)
 
-    ##Add name as metadata
-    if acquisition_system == 'cambridge_attolight':
-        #Import file name
-        experiment_name = os.path.split(hypcard_folder)[1]
-        #CAUTION: Specifically delimeted by Attolight default naming system
+    # Add name as metadata
+    if attolight_acquisition_system == 'cambridge_attolight':
+        # Import file name
+        experiment_name = os.path.basename(hypcard_folder)
+        # CAUTION: Specifically delimeted by Attolight default naming system
         try:
             name = experiment_name[:-37]
         except:
             name = experiment_name
         s.metadata.General.title = name
 
-    #Calibrate navigation axis
-    calibrate_navigation_axis(s)
+    # Calibrate navigation axis
+    _calibrate_navigation_axis(s)
 
-    #Calibrate signal axis
-    calibrate_signal_axis_wavelength(s)
+    # Calibrate signal axis
+    _calibrate_signal_axis_wavelength(s)
 
-    #Save background file if exisent (after calibrating signal axis)
-    save_background(s, hypcard_folder)
+    # Save background file if exisent (after calibrating signal axis)
+    _save_background(s, hypcard_folder)
 
-    return(s)
+    return s
+

--- a/lumispy/signals/cl_sem_spectrum.py
+++ b/lumispy/signals/cl_sem_spectrum.py
@@ -25,8 +25,6 @@ import numpy as np
 from lumispy.signals.cl_spectrum import CLSpectrum
 from hyperspy._signals.lazy import LazySignal
 
-from lumispy.utils.acquisition_systems import acquisition_systems
-
 
 class CLSEMSpectrum(CLSpectrum):
     _signal_type = "CL_SEM_Spectrum"
@@ -74,6 +72,8 @@ class CLSEMSpectrum(CLSpectrum):
 
         Authorship: Gunnar Kusch (gk419@cam.ac.uk)
         """
+        from lumispy.io_plugins.attolight import attolight_systems
+
         # Avoid correcting for this shift twice (first time it fails, so except
         # block runs. Second time, try succeeds, so except block is skipped):
         try:
@@ -88,17 +88,17 @@ class CLSEMSpectrum(CLSpectrum):
             fov = md.Acquisition_instrument.SEM.FOV
             acquisition_system = md.Acquisition_instrument.acquisition_system
 
-            cal_factor_x_axis = acquisition_systems[acquisition_system]['cal_factor_x_axis']
+            cal_factor_x_axis = attolight_systems[acquisition_system]['cal_factor_x_axis']
 
             # Get the correction factor for the relevant grating (extracted from
             # the acquisition_systems dictionary)
             try:
-                corrfactor = acquisition_systems[acquisition_system]['grating_corrfactors'][grating]
+                corrfactor = attolight_systems[acquisition_system]['grating_corrfactors'][grating]
             except:
                 raise Exception("Sorry, the grating is not calibrated yet. "
-                                "No grating shift corraction can be applied. "
-                                "Go to lumispy.utils.acquisition_systems and "
-                                "add the missing grating_corrfactors")
+                                "No grating shift correction can be applied. "
+                                "Go to lumispy.io.attolight and "
+                                "add the missing grating_corrfactors in the attolight_sysyems dict.")
 
             # Correction of the Wavelength Shift along the X-Axis
             calax = cal_factor_x_axis / (fov * nx)


### PR DESCRIPTION
Solving #16 .
Created a modified version of `hs.io.load()` as `lum.io.load()`. The `hs.io.load_single_file()` is modified so it first checks for io_plugins files in lumispy, and if it doesn't find any, then it runs the normal hs.io.load_single_file() from hyperspy.

For now it does the job perfectly, supporting any new file type in the lumispy/io_plugins but also supporting all the hyperspy io_plugins too.

In further PRs, another method should be attempted by adding the `io_plugin` of Attolight to the Hyperspy package.
This will require longer time to be approved, so for now this is a working fix and it makes the process of transporting this code to hyperspy easier.