### PR TITLE
Added signal_dimension = -1 to CommonLumi

### DIFF
--- a/lumispy/hyperspy_extension.yaml
+++ b/lumispy/hyperspy_extension.yaml
@@ -22,6 +22,7 @@ signals:
     signal_type_aliases:
       - Luminescence BaseSignal
       - luminescence
+    signal_dimension: -1
     dtype: real
     lazy: False
     module: lumispy.signals.common_luminescence
@@ -137,6 +138,7 @@ signals:
         dtype: real
         lazy: True
         module: lumispy.signals.cl_stem_spectrum
+
     LumiTransient:
       signal_type: "Luminescence_2D"
       signal_type_aliases:

--- a/lumispy/signals/cl_sem_spectrum.py
+++ b/lumispy/signals/cl_sem_spectrum.py
@@ -96,7 +96,7 @@ class CLSEMSpectrum(CLSpectrum):
                 corrfactor = acquisition_systems[acquisition_system]['grating_corrfactors'][grating]
             except:
                 raise Exception("Sorry, the grating is not calibrated yet. "
-                                "No grating shift corraction can be applied. "
+                                "No grating shift correction can be applied. "
                                 "Go to lumispy.utils.acquisition_systems and "
                                 "add the missing grating_corrfactors")
 


### PR DESCRIPTION
Its absence was causing a failure of the hyperspy load function in my installation: 
Keyerror in assign_signal_subclass

