### PR TITLE
Fix signal registration

### DIFF
--- a/lumispy.egg-info/.gitignore
+++ b/lumispy.egg-info/.gitignore
@@ -1,0 +1,6 @@
+/PKG-INFO
+/SOURCES.txt
+/dependency_links.txt
+/entry_points.txt
+/requires.txt
+/top_level.txt

--- a/lumispy/__init__.py
+++ b/lumispy/__init__.py
@@ -17,14 +17,9 @@
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import glob
 import logging
-import os
-import warnings
 
 from hyperspy.io import load as hyperspyload
-#from hyperspy.api import roi
-from lumispy.signals import push_metadata_through
 
 import numpy as np
 

--- a/lumispy/__init__.py
+++ b/lumispy/__init__.py
@@ -25,7 +25,6 @@ import numpy as np
 
 from natsort import natsorted
 
-from .signals.common_luminescence import CommonLumi
 from .signals.luminescence_spectrum import LumiSpectrum
 from .signals.cl_spectrum import CLSpectrum
 from .signals.cl_sem_spectrum import CLSEMSpectrum

--- a/lumispy/hyperspy_extension.yaml
+++ b/lumispy/hyperspy_extension.yaml
@@ -62,15 +62,15 @@ signals:
     dtype: real
     lazy: False
     module: lumispy.signals.el_spectrum
-    LazyELSpectrum:
-      signal_type: EL
-      signal_type_aliases:
-        - EL
-        - electroluminescence
-      signal_dimension: 1
-      dtype: real
-      lazy: True
-      module: lumispy.signals.el_spectrum
+  LazyELSpectrum:
+    signal_type: EL
+    signal_type_aliases:
+      - EL
+      - electroluminescence
+    signal_dimension: 1
+    dtype: real
+    lazy: True
+    module: lumispy.signals.el_spectrum
 
   PLSpectrum:
     signal_type: PL
@@ -81,15 +81,15 @@ signals:
     dtype: real
     lazy: False
     module: lumispy.signals.pl_spectrum
-    LazyPLSpectrum:
-      signal_type: PL_Spectrum
-      signal_type_aliases:
-        - PL
-        - photoluminescence
-      signal_dimension: 1
-      dtype: real
-      lazy: True
-      module: lumispy.signals.pl_spectrum
+  LazyPLSpectrum:
+    signal_type: PL
+    signal_type_aliases:
+      - PL
+      - photoluminescence
+    signal_dimension: 1
+    dtype: real
+    lazy: True
+    module: lumispy.signals.pl_spectrum
 
   CLSEMSpectrum:
     signal_type: CL_SEM

--- a/lumispy/hyperspy_extension.yaml
+++ b/lumispy/hyperspy_extension.yaml
@@ -18,7 +18,7 @@
 
 signals:
   CommonLumi:
-    signal_type: "Luminescence"
+    signal_type: Luminescence
     signal_type_aliases:
       - Luminescence BaseSignal
       - luminescence
@@ -28,24 +28,24 @@ signals:
     module: lumispy.signals.common_luminescence
 
   LumiSpectrum:
-    signal_type: "Luminescence_Spectrum"
+    signal_type: Luminescence_Spectrum
     signal_type_aliases:
       - LuminescenceSpectrum
     signal_dimension: 1
     dtype: real
     lazy: False
     module: lumispy.signals.luminescence_spectrum
-    LazyLumiSpectrum:
-      signal_type: "Luminescence_Spectrum"
-      signal_type_aliases:
-        - LuminescenceSpectrum
-      signal_dimension: 1
-      dtype: real
-      lazy: True
-      module: lumispy.signals.luminescence_spectrum
+  LazyLumiSpectrum:
+    signal_type: Luminescence_Spectrum
+    signal_type_aliases:
+      - LuminescenceSpectrum
+    signal_dimension: 1
+    dtype: real
+    lazy: True
+    module: lumispy.signals.luminescence_spectrum
 
   CLSpectrum:
-    signal_type: "CL_Spectrum"
+    signal_type: CL_Spectrum
     signal_type_aliases:
       - CL
       - cathodoluminescence
@@ -53,107 +53,107 @@ signals:
     dtype: real
     lazy: False
     module: lumispy.signals.cl_spectrum
-    LazyCLSpectrum:
-      signal_type: "CL_Spectrum"
-      signal_type_aliases:
-        - CL
-        - cathodoluminescence
-      signal_dimension: 1
-      dtype: real
-      lazy: True
-      module: lumispy.signals.cl_spectrum
+  LazyCLSpectrum:
+    signal_type: CL_Spectrum
+    signal_type_aliases:
+      - CL
+      - cathodoluminescence
+    signal_dimension: 1
+    dtype: real
+    lazy: True
+    module: lumispy.signals.cl_spectrum
 
-    ELSpectrum:
-      signal_type: "EL_Spectrum"
+  ELSpectrum:
+    signal_type: EL_Spectrum
+    signal_type_aliases:
+      - EL
+      - electroluminescence
+    signal_dimension: 1
+    dtype: real
+    lazy: False
+    module: lumispy.signals.el_spectrum
+    LazyELSpectrum:
+      signal_type: EL_Spectrum
       signal_type_aliases:
         - EL
         - electroluminescence
       signal_dimension: 1
       dtype: real
-      lazy: False
+      lazy: True
       module: lumispy.signals.el_spectrum
-      LazyELSpectrum:
-        signal_type: "EL_Spectrum"
-        signal_type_aliases:
-          - EL
-          - electroluminescence
-        signal_dimension: 1
-        dtype: real
-        lazy: True
-        module: lumispy.signals.el_spectrum
 
-    PLSpectrum:
-      signal_type: "PL_Spectrum"
+  PLSpectrum:
+    signal_type: PL_Spectrum
+    signal_type_aliases:
+      - PL
+      - photoluminescence
+    signal_dimension: 1
+    dtype: real
+    lazy: False
+    module: lumispy.signals.pl_spectrum
+    LazyPLSpectrum:
+      signal_type: PL_Spectrum
       signal_type_aliases:
         - PL
         - photoluminescence
       signal_dimension: 1
       dtype: real
-      lazy: False
+      lazy: True
       module: lumispy.signals.pl_spectrum
-      LazyPLSpectrum:
-        signal_type: "PL_Spectrum"
-        signal_type_aliases:
-          - PL
-          - photoluminescence
-        signal_dimension: 1
-        dtype: real
-        lazy: True
-        module: lumispy.signals.pl_spectrum
 
-    CLSEMSpectrum:
-      signal_type: "CL_SEM_Spectrum"
-      signal_type_aliases:
-        - CLSEM
-        - cathodoluminescence SEM
-      signal_dimension: 1
-      dtype: real
-      lazy: False
-      module: lumispy.signals.cl_sem_spectrum
-      LazyCLSEMSpectrum:
-        signal_type: "CL_SEM_Spectrum"
-        signal_type_aliases:
-          - CLSEM
-          - cathodoluminescence SEM
-        signal_dimension: 1
-        dtype: real
-        lazy: True
-        module: lumispy.signals.cl_sem_spectrum
+  CLSEMSpectrum:
+    signal_type: CL_SEM_Spectrum
+    signal_type_aliases:
+      - CLSEM
+      - cathodoluminescence SEM
+    signal_dimension: 1
+    dtype: real
+    lazy: False
+    module: lumispy.signals.cl_sem_spectrum
+  LazyCLSEMSpectrum:
+    signal_type: CL_SEM_Spectrum
+    signal_type_aliases:
+      - CLSEM
+      - cathodoluminescence SEM
+    signal_dimension: 1
+    dtype: real
+    lazy: True
+    module: lumispy.signals.cl_sem_spectrum
 
-    CLSTEMSpectrum:
-      signal_type: "CL_STEM_Spectrum"
-      signal_type_aliases:
-        - CLSTEM
-        - cathodoluminescence STEM
-      signal_dimension: 1
-      dtype: real
-      lazy: False
-      module: lumispy.signals.cl_stem_spectrum
-      LazyCLSTEMSpectrum:
-        signal_type: "CL_STEM_Spectrum"
-        signal_type_aliases:
-          - CLSTEM
-          - cathodoluminescence STEM
-        signal_dimension: 1
-        dtype: real
-        lazy: True
-        module: lumispy.signals.cl_stem_spectrum
+  CLSTEMSpectrum:
+    signal_type: CL_STEM_Spectrum
+    signal_type_aliases:
+      - CLSTEM
+      - cathodoluminescence STEM
+    signal_dimension: 1
+    dtype: real
+    lazy: False
+    module: lumispy.signals.cl_stem_spectrum
+  LazyCLSTEMSpectrum:
+    signal_type: CL_STEM_Spectrum
+    signal_type_aliases:
+      - CLSTEM
+      - cathodoluminescence STEM
+    signal_dimension: 1
+    dtype: real
+    lazy: True
+    module: lumispy.signals.cl_stem_spectrum
 
-    LumiTransient:
-      signal_type: "Luminescence_2D"
-      signal_type_aliases:
-        - TRLumi
-        - TR luminescence
-      signal_dimension: 2
-      dtype: real
-      lazy: False
-      module: lumispy.signals.luminescence_transient
-      LazyLumiSpectrum:
-        signal_type: "Luminescence_2D"
-        signal_type_aliases:
-          - TR Luminescence
-          - TRLumi
-        signal_dimension: 2
-        dtype: real
-        lazy: True
-        module: lumispy.signals.luminescence_transient
+  LumiTransient:
+    signal_type: Luminescence_2D
+    signal_type_aliases:
+      - TRLumi
+      - TR luminescence
+    signal_dimension: 2
+    dtype: real
+    lazy: False
+    module: lumispy.signals.luminescence_transient
+  LazyLumiSpectrum:
+    signal_type: Luminescence_2D
+    signal_type_aliases:
+      - TR Luminescence
+      - TRLumi
+    signal_dimension: 2
+    dtype: real
+    lazy: True
+    module: lumispy.signals.luminescence_transient

--- a/lumispy/hyperspy_extension.yaml
+++ b/lumispy/hyperspy_extension.yaml
@@ -17,18 +17,8 @@
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 signals:
-  CommonLumi:
-    signal_type: Luminescence
-    signal_type_aliases:
-      - Luminescence BaseSignal
-      - luminescence
-    signal_dimension: -1
-    dtype: real
-    lazy: False
-    module: lumispy.signals.common_luminescence
-
   LumiSpectrum:
-    signal_type: Luminescence_Spectrum
+    signal_type: Luminescence
     signal_type_aliases:
       - LuminescenceSpectrum
     signal_dimension: 1
@@ -36,7 +26,7 @@ signals:
     lazy: False
     module: lumispy.signals.luminescence_spectrum
   LazyLumiSpectrum:
-    signal_type: Luminescence_Spectrum
+    signal_type: Luminescence
     signal_type_aliases:
       - LuminescenceSpectrum
     signal_dimension: 1
@@ -45,7 +35,7 @@ signals:
     module: lumispy.signals.luminescence_spectrum
 
   CLSpectrum:
-    signal_type: CL_Spectrum
+    signal_type: CL
     signal_type_aliases:
       - CL
       - cathodoluminescence
@@ -54,7 +44,7 @@ signals:
     lazy: False
     module: lumispy.signals.cl_spectrum
   LazyCLSpectrum:
-    signal_type: CL_Spectrum
+    signal_type: CL
     signal_type_aliases:
       - CL
       - cathodoluminescence
@@ -64,7 +54,7 @@ signals:
     module: lumispy.signals.cl_spectrum
 
   ELSpectrum:
-    signal_type: EL_Spectrum
+    signal_type: EL
     signal_type_aliases:
       - EL
       - electroluminescence
@@ -73,7 +63,7 @@ signals:
     lazy: False
     module: lumispy.signals.el_spectrum
     LazyELSpectrum:
-      signal_type: EL_Spectrum
+      signal_type: EL
       signal_type_aliases:
         - EL
         - electroluminescence
@@ -83,7 +73,7 @@ signals:
       module: lumispy.signals.el_spectrum
 
   PLSpectrum:
-    signal_type: PL_Spectrum
+    signal_type: PL
     signal_type_aliases:
       - PL
       - photoluminescence
@@ -102,7 +92,7 @@ signals:
       module: lumispy.signals.pl_spectrum
 
   CLSEMSpectrum:
-    signal_type: CL_SEM_Spectrum
+    signal_type: CL_SEM
     signal_type_aliases:
       - CLSEM
       - cathodoluminescence SEM
@@ -111,7 +101,7 @@ signals:
     lazy: False
     module: lumispy.signals.cl_sem_spectrum
   LazyCLSEMSpectrum:
-    signal_type: CL_SEM_Spectrum
+    signal_type: CL_SEM
     signal_type_aliases:
       - CLSEM
       - cathodoluminescence SEM
@@ -121,7 +111,7 @@ signals:
     module: lumispy.signals.cl_sem_spectrum
 
   CLSTEMSpectrum:
-    signal_type: CL_STEM_Spectrum
+    signal_type: CL_STEM
     signal_type_aliases:
       - CLSTEM
       - cathodoluminescence STEM
@@ -130,7 +120,7 @@ signals:
     lazy: False
     module: lumispy.signals.cl_stem_spectrum
   LazyCLSTEMSpectrum:
-    signal_type: CL_STEM_Spectrum
+    signal_type: CL_STEM
     signal_type_aliases:
       - CLSTEM
       - cathodoluminescence STEM
@@ -140,7 +130,7 @@ signals:
     module: lumispy.signals.cl_stem_spectrum
 
   LumiTransient:
-    signal_type: Luminescence_2D
+    signal_type: Luminescence
     signal_type_aliases:
       - TRLumi
       - TR luminescence
@@ -148,8 +138,8 @@ signals:
     dtype: real
     lazy: False
     module: lumispy.signals.luminescence_transient
-  LazyLumiSpectrum:
-    signal_type: Luminescence_2D
+  LazyLumiTransient:
+    signal_type: Luminescence
     signal_type_aliases:
       - TR Luminescence
       - TRLumi

--- a/lumispy/signals/__init__.py
+++ b/lumispy/signals/__init__.py
@@ -15,35 +15,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
-
-
-def push_metadata_through(dummy, *args, **kwargs):
-    """
-    This function pushes loaded metadata through to lumispy objects, it is to
-    be used for one purpose.
-
-    Parameters
-    ----------
-    dummy :
-        This will always be the "self" of the object to be initialised
-
-    args : list
-        This will always be the "args" of the object to be initialised
-
-    kwargs : dict
-        This will always be the "args" of the object to be initialised
-
-    Returns
-    -------
-    dummy,args,kwargs :
-        The input variables, adjusted correctly
-    """
-    try:
-        meta_dict = args[0].metadata.as_dictionary()
-        kwargs.update({'metadata': meta_dict})
-    except AttributeError:
-        pass  # this is because a numpy array has been passed
-    except IndexError:
-        pass  # this means that map continues to work.
-
-    return dummy, args, kwargs

--- a/lumispy/signals/cl_sem_spectrum.py
+++ b/lumispy/signals/cl_sem_spectrum.py
@@ -27,7 +27,7 @@ from hyperspy._signals.lazy import LazySignal
 
 
 class CLSEMSpectrum(CLSpectrum):
-    _signal_type = "CL_SEM_Spectrum"
+    _signal_type = "CL_SEM"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/lumispy/signals/cl_sem_spectrum.py
+++ b/lumispy/signals/cl_sem_spectrum.py
@@ -29,33 +29,6 @@ from hyperspy._signals.lazy import LazySignal
 class CLSEMSpectrum(CLSpectrum):
     _signal_type = "CL_SEM"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def as_lazy(self, *args, **kwargs):
-        """Create a copy of the CLSpectrum object as a
-        :py:class:`~lumispy.signals.cl.LazyCLSEMSpectrum`.
-
-        Parameters
-        ----------
-        copy_variance : bool
-            If True variance from the original CLSEMSpectrum object is copied
-            to the new CLSEMSpectrum object.
-
-        Returns
-        -------
-        res : :py:class:`~lumispy.signals.cl.CLSEMSpectrum`.
-            The lazy signal.
-        """
-        res = super().as_lazy(*args, **kwargs)
-        res.__class__ = LazyCLSEMSpectrum
-        res.__init__(**res._to_dictionary())
-        return res
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = CLSEMSpectrum
-
     def correct_grating_shift(self):
         """"
         Applies shift caused by the grating offset wrt the scanning centre.
@@ -118,14 +91,4 @@ class CLSEMSpectrum(CLSpectrum):
 class LazyCLSEMSpectrum(LazySignal, CLSEMSpectrum):
     _lazy = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def compute(self, *args, **kwargs):
-        super().compute(*args, **kwargs)
-        self.__class__ = CLSEMSpectrum
-        self.__init__(**self._to_dictionary())
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LazyCLSEMSpectrum
+    pass

--- a/lumispy/signals/cl_spectrum.py
+++ b/lumispy/signals/cl_spectrum.py
@@ -30,7 +30,7 @@ class CLSpectrum(LumiSpectrum):
     """General 1D Cathodoluminescence signal class.
     ----------
     """
-    _signal_type = "CL_Spectrum"
+    _signal_type = "CL"
     _signal_dimension = 1
 
     def __init__(self, *args, **kwargs):

--- a/lumispy/signals/cl_spectrum.py
+++ b/lumispy/signals/cl_spectrum.py
@@ -33,33 +33,6 @@ class CLSpectrum(LumiSpectrum):
     _signal_type = "CL"
     _signal_dimension = 1
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def as_lazy(self, *args, **kwargs):
-        """Create a copy of the Signal1D object as a
-        :py:class:`~lumispy.signals.cl.CLSpectrum`.
-
-        Parameters
-        ----------
-        copy_variance : bool
-            If True variance from the original CLSpectrum object is copied to
-            the new LazyCLSpectrum object.
-
-        Returns
-        -------
-        res : :py:class:`~lumispy.signals.cl.CLSpectrum`.
-            The lazy signal.
-        """
-        res = super().as_lazy(*args, **kwargs)
-        res.__class__ = LazyCLSpectrum
-        res.__init__(**res._to_dictionary())
-        return res
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = CLSpectrum
-
     def cosmic_rays_subtraction(self, extra_percent=50, inplace=False, **kwargs):
         """
         Masks the cosmic rays away
@@ -108,14 +81,4 @@ class CLSpectrum(LumiSpectrum):
 class LazyCLSpectrum(LazySignal, CLSpectrum):
     _lazy = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def compute(self, *args, **kwargs):
-        super().compute(*args, **kwargs)
-        self.__class__ = CLSpectrum
-        self.__init__(**self._to_dictionary())
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LazyCLSpectrum
+    pass

--- a/lumispy/signals/cl_stem_spectrum.py
+++ b/lumispy/signals/cl_stem_spectrum.py
@@ -25,7 +25,7 @@ from hyperspy._signals.lazy import LazySignal
 
 
 class CLSTEMSpectrum(CLSpectrum):
-    _signal_type = "CL_STEM_Spectrum"
+    _signal_type = "CL_STEM"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/lumispy/signals/cl_stem_spectrum.py
+++ b/lumispy/signals/cl_stem_spectrum.py
@@ -25,48 +25,14 @@ from hyperspy._signals.lazy import LazySignal
 
 
 class CLSTEMSpectrum(CLSpectrum):
+
     _signal_type = "CL_STEM"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def as_lazy(self, *args, **kwargs):
-        """Create a copy of the CLSTEMSpectrum object as a
-        :py:class:`~lumispy.signals.cl.CLSTEMSpectrum`.
-
-        Parameters
-        ----------
-        copy_variance : bool
-            If True variance from the original CLSTEMSpectrum object is copied
-            to the new CLSTEMSpectrum object.
-
-        Returns
-        -------
-        res : :py:class:`~lumispy.signals.cl.LazyCLSTEMSpectrum`.
-            The lazy signal.
-        """
-        res = super().as_lazy(*args, **kwargs)
-        res.__class__ = LazyCLSTEMSpectrum
-        res.__init__(**res._to_dictionary())
-        return res
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = CLSTEMSpectrum
+    pass
 
 
 class LazyCLSTEMSpectrum(LazySignal, CLSTEMSpectrum):
 
     _lazy = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def compute(self, *args, **kwargs):
-        super().compute(*args, **kwargs)
-        self.__class__ = CLSTEMSpectrum
-        self.__init__(**self._to_dictionary())
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LazyCLSTEMSpectrum
+    pass

--- a/lumispy/signals/common_luminescence.py
+++ b/lumispy/signals/common_luminescence.py
@@ -19,22 +19,13 @@
 """Signal class for Luminescence data (BaseSignal class).
 """
 
-import numpy as np
 
-from hyperspy.signal import BaseSignal
-
-
-class CommonLumi(BaseSignal):
+class CommonLumi:
     """General Luminescence signal class (dimensionless).
     ----------
     background : array
         Array containing [wavelength, background].
     """
-    _signal_type = "Luminescence"
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.background = None
 
     def crop_edges(self, crop_px):
         """

--- a/lumispy/signals/el_spectrum.py
+++ b/lumispy/signals/el_spectrum.py
@@ -20,8 +20,6 @@
 
 """
 
-import numpy as np
-
 from hyperspy._signals.lazy import LazySignal
 from lumispy.signals.luminescence_spectrum import LumiSpectrum
 
@@ -33,45 +31,10 @@ class ELSpectrum(LumiSpectrum):
     _signal_type = "EL"
     _signal_dimension = 1
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def as_lazy(self, *args, **kwargs):
-        """Create a copy of the Signal1D object as a
-        :py:class:`~lumispy.signals.cl.ELSpectrum`.
-
-        Parameters
-        ----------
-        copy_variance : bool
-            If True variance from the original ELSpectrum object is copied to
-            the new LazyELSpectrum object.
-
-        Returns
-        -------
-        res : :py:class:`~lumispy.signals.cl.ELSpectrum`.
-            The lazy signal.
-        """
-        res = super().as_lazy(*args, **kwargs)
-        res.__class__ = LazyELSpectrum
-        res.__init__(**res._to_dictionary())
-        return res
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = ELSpectrum
+    pass
 
 
 class LazyELSpectrum(LazySignal, ELSpectrum):
     _lazy = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def compute(self, *args, **kwargs):
-        super().compute(*args, **kwargs)
-        self.__class__ = ELSpectrum
-        self.__init__(**self._to_dictionary())
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LazyELSpectrum
+    pass

--- a/lumispy/signals/el_spectrum.py
+++ b/lumispy/signals/el_spectrum.py
@@ -30,7 +30,7 @@ class ELSpectrum(LumiSpectrum):
     """General 1D Electroluminescence signal class.
     ----------
     """
-    _signal_type = "EL_Spectrum"
+    _signal_type = "EL"
     _signal_dimension = 1
 
     def __init__(self, *args, **kwargs):

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -19,8 +19,6 @@
 """Signal class for Luminescence spectral data (1D).
 """
 
-import numpy as np
-
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy._signals.lazy import LazySignal
 from lumispy.signals.common_luminescence import CommonLumi
@@ -39,42 +37,8 @@ class LumiSpectrum(Signal1D, CommonLumi):
         super().__init__(*args, **kwargs)
         self.background = None
 
-    def as_lazy(self, *args, **kwargs):
-        """Create a copy of the Signal1D object as a
-        :py:class:`~lumispy.signals.cl.LumiSpectrum`.
-
-        Parameters
-        ----------
-        copy_variance : bool
-            If True variance from the original LumiSpectrum object is copied to
-            the new LazyLumiSpectrum object.
-
-        Returns
-        -------
-        res : :py:class:`~lumispy.signals.cl.LumiSpectrum`.
-            The lazy signal.
-        """
-        res = super().as_lazy(*args, **kwargs)
-        res.__class__ = LazyLumiSpectrum
-        res.__init__(**res._to_dictionary())
-        return res
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LumiSpectrum
-
 
 class LazyLumiSpectrum(LazySignal, LumiSpectrum):
     _lazy = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def compute(self, *args, **kwargs):
-        super().compute(*args, **kwargs)
-        self.__class__ = LumiSpectrum
-        self.__init__(**self._to_dictionary())
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LazyLumiSpectrum
+    pass

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -32,7 +32,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
     background : array
         Array containing [wavelength, background].
     """
-    _signal_type = "Luminescence_Spectrum"
+    _signal_type = "Luminescence"
     _signal_dimension = 1
 
     def __init__(self, *args, **kwargs):

--- a/lumispy/signals/luminescence_transient.py
+++ b/lumispy/signals/luminescence_transient.py
@@ -27,7 +27,7 @@ from lumispy.signals.common_luminescence import CommonLumi
 class LumiTransient(Signal2D, CommonLumi):
     """General 2D Luminescence signal class (transient/time resolved).
     """
-    _signal_type = "Luminescence_2D"
+    _signal_type = "Luminescence"
     _signal_dimension = 2
 
     def __init__(self, *args, **kwargs):

--- a/lumispy/signals/luminescence_transient.py
+++ b/lumispy/signals/luminescence_transient.py
@@ -30,45 +30,10 @@ class LumiTransient(Signal2D, CommonLumi):
     _signal_type = "Luminescence"
     _signal_dimension = 2
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def as_lazy(self, *args, **kwargs):
-        """Create a copy of the Signal2D object as a
-        :py:class:`~lumispy.signals.cl.LumiTransient`.
-
-        Parameters
-        ----------
-        copy_variance : bool
-            If True variance from the original LumiTransient object is copied to
-            the new LazyLumiTransient object.
-
-        Returns
-        -------
-        res : :py:class:`~lumispy.signals.cl.LumiTransient`.
-            The lazy signal.
-        """
-        res = super().as_lazy(*args, **kwargs)
-        res.__class__ = LazyLumiTransient
-        res.__init__(**res._to_dictionary())
-        return res
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LumiTransient
+    pass
 
 
 class LazyLumiTransient(LazySignal, LumiTransient):
     _lazy = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def compute(self, *args, **kwargs):
-        super().compute(*args, **kwargs)
-        self.__class__ = LumiTransient
-        self.__init__(**self._to_dictionary())
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LazyLumiTransient
+    pass

--- a/lumispy/signals/pl_spectrum.py
+++ b/lumispy/signals/pl_spectrum.py
@@ -30,7 +30,7 @@ class PLSpectrum(LumiSpectrum):
     """General 1D Photoluminescence signal class.
     ----------
     """
-    _signal_type = "PL_Spectrum"
+    _signal_type = "PL"
     _signal_dimension = 1
 
     def __init__(self, *args, **kwargs):

--- a/lumispy/signals/pl_spectrum.py
+++ b/lumispy/signals/pl_spectrum.py
@@ -20,8 +20,6 @@
 
 """
 
-import numpy as np
-
 from hyperspy._signals.lazy import LazySignal
 from lumispy.signals.luminescence_spectrum import LumiSpectrum
 
@@ -33,45 +31,11 @@ class PLSpectrum(LumiSpectrum):
     _signal_type = "PL"
     _signal_dimension = 1
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def as_lazy(self, *args, **kwargs):
-        """Create a copy of the Signal1D object as a
-        :py:class:`~lumispy.signals.cl.PLSpectrum`.
-
-        Parameters
-        ----------
-        copy_variance : bool
-            If True variance from the original PLSpectrum object is copied to
-            the new LazyPLSpectrum object.
-
-        Returns
-        -------
-        res : :py:class:`~lumispy.signals.cl.PLSpectrum`.
-            The lazy signal.
-        """
-        res = super().as_lazy(*args, **kwargs)
-        res.__class__ = LazyPLSpectrum
-        res.__init__(**res._to_dictionary())
-        return res
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = PLSpectrum
+    pass
 
 
 class LazyPLSpectrum(LazySignal, PLSpectrum):
+
     _lazy = True
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def compute(self, *args, **kwargs):
-        super().compute(*args, **kwargs)
-        self.__class__ = PLSpectrum
-        self.__init__(**self._to_dictionary())
-
-    def decomposition(self, *args, **kwargs):
-        super().decomposition(*args, **kwargs)
-        self.__class__ = LazyPLSpectrum
+    pass

--- a/lumispy/tests/test_signal_registration.py
+++ b/lumispy/tests/test_signal_registration.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+import hyperspy.api as hs
+import numpy as np
+
+
+from lumispy import (LumiSpectrum, CLSpectrum, CLSEMSpectrum, CLSTEMSpectrum,
+                     PLSpectrum, ELSpectrum, LumiTransient, LazyLumiSpectrum,
+                     LazyCLSpectrum, LazyCLSEMSpectrum, LazyCLSTEMSpectrum,
+                     LazyPLSpectrum, LazyELSpectrum, LazyLumiTransient)
+
+
+signal1d_class_list = [LumiSpectrum, CLSpectrum, CLSEMSpectrum, CLSTEMSpectrum,
+                       PLSpectrum, ELSpectrum, LazyLumiSpectrum,
+                       LazyCLSpectrum, LazyCLSEMSpectrum, LazyCLSTEMSpectrum,
+                       LazyPLSpectrum, LazyELSpectrum]
+signal2d_class_list = [LumiTransient, LazyLumiTransient]
+
+
+@pytest.mark.parametrize("signal_class", signal1d_class_list)
+def test_signal_registration1d(signal_class):
+    s = signal_class(0)
+
+    s2 = hs.signals.Signal1D([0, 1, 2])
+    s2.set_signal_type(s._signal_type)
+    assert isinstance(s2, signal_class)
+
+
+@pytest.mark.parametrize("signal_class", signal2d_class_list)
+def test_signal_registration2d(signal_class):
+    s = signal_class(0)
+
+    s2 = hs.signals.Signal2D(np.arange(100).reshape((10, 10)))
+    s2.set_signal_type(s._signal_type)
+    assert isinstance(s2, signal_class)

--- a/lumispy/tests/test_signal_registration.py
+++ b/lumispy/tests/test_signal_registration.py
@@ -39,14 +39,25 @@ def test_signal_registration1d(signal_class):
     s = signal_class(0)
 
     s2 = hs.signals.Signal1D([0, 1, 2])
+    if s._lazy:
+        s2 = s2.as_lazy()
+
+    print("signal_type:", s._signal_type)
+
     s2.set_signal_type(s._signal_type)
     assert isinstance(s2, signal_class)
 
 
 @pytest.mark.parametrize("signal_class", signal2d_class_list)
 def test_signal_registration2d(signal_class):
-    s = signal_class(0)
+    data = np.arange(1000).reshape((10, 10, 10))
+    s = signal_class(data)
 
-    s2 = hs.signals.Signal2D(np.arange(100).reshape((10, 10)))
+    s2 = hs.signals.Signal2D(data)
+    if s._lazy:
+        s2 = s2.as_lazy()
+
+    print("signal_type:", s._signal_type)
+
     s2.set_signal_type(s._signal_type)
     assert isinstance(s2, signal_class)


### PR DESCRIPTION
Now the signal should be registered and setting the `signal_type` will assign to the correct class when loading data or changing class (dimension change or from to lazy signal).

- [x] Fix signal registration,
- [x] remove unnecessary boiling plate code,
- [x] add test.

To verify:

```python
>>> import hyperspy.api as hs
>>> hs.print_known_signal_types()
+----------------------------+----------------------------------+----------------------------+----------+
|        signal_type         |             aliases              |         class name         | package  |
+----------------------------+----------------------------------+----------------------------+----------+
|           CL_SEM           |  CLSEM, cathodoluminescence SEM  |       CLSEMSpectrum        | lumispy  |
|          CL_STEM           | CLSTEM, cathodoluminescence STEM |       CLSTEMSpectrum       | lumispy  |
|             CL             |     CL, cathodoluminescence      |         CLSpectrum         | lumispy  |
|     DielectricFunction     |       dielectric function        |     DielectricFunction     | hyperspy |
|          EDS_SEM           |                                  |       EDSSEMSpectrum       | hyperspy |
|          EDS_TEM           |                                  |       EDSTEMSpectrum       | hyperspy |
|            EELS            |             TEM EELS             |        EELSSpectrum        | hyperspy |
|             EL             |     EL, electroluminescence      |         ELSpectrum         | lumispy  |
|          hologram          |                                  |       HologramImage        | hyperspy |
|        Luminescence        |       LuminescenceSpectrum       |        LumiSpectrum        | lumispy  |
|        Luminescence        |     TRLumi, TR luminescence      |       LumiTransient        | lumispy  |
|             PL             |      PL, photoluminescence       |         PLSpectrum         | lumispy  |
+----------------------------+----------------------------------+----------------------------+----------+

```