### PR TITLE
Saving background in the metadata, not as a CommonLumi object parameter.

### DIFF
--- a/lumispy/io_plugins/attolight.py
+++ b/lumispy/io_plugins/attolight.py
@@ -244,39 +244,27 @@ def file_reader(filename, *args, **kwds):
 
         return cl_object
 
-    def _save_background(cl_object, hypcard_folder, background_file_name='Background*.txt'):
+    def _save_background_metadata(cl_object, hypcard_folder, background_file_name='Background*.txt'):
         """
         Based on the Attolight background savefunction.
-        If background is found in the folder, it saves background as a cl_object.background attribute.
-
-        Returns
-        ----------
-        cl_object:
-            With the background saved as a background attribute.
+        If background is found in the folder, it saves background as in the metadata.
         """
         # Get the absolute path
         path = os.path.join(hypcard_folder, background_file_name)
+
         # Try to load the file, if it exists.
         try:
             # Find the exact filename, using the * wildcard
             path = glob.glob(path)[0]
             # Load the file as a numpy array
             bkg = np.loadtxt(path)
-            # Extract only the  signal axis
-            # ERROR from AttoLight bug
-            bkg = bkg[1]
-            # Retrieve the correct x axis from the cl_object
-            # ERROR from AttoLight bug
-            x_axis = cl_object.axes_manager.signal_axes[0].axis
-            # Join x axis with bkg signal
-            background = [x_axis, bkg]
-            # Store the value as background attribute
-            cl_object.background = background
+            # The bkg file contains [wavelength, background]
+            cl_object.metadata.set_item("Signal.background", bkg)
+            return cl_object
+        except:
+            cl_object.metadata.set_item("Signal.background", None)
             return cl_object
 
-        # If file does not exist, return function
-        except:
-            return
 
     #################################
 
@@ -342,7 +330,7 @@ def file_reader(filename, *args, **kwds):
     _calibrate_signal_axis_wavelength(s)
 
     # Save background file if exisent (after calibrating signal axis)
-    _save_background(s, hypcard_folder)
+    _save_background_metadata(s, hypcard_folder,)
 
     return s
 

--- a/lumispy/signals/common_luminescence.py
+++ b/lumispy/signals/common_luminescence.py
@@ -23,8 +23,6 @@
 class CommonLumi:
     """General Luminescence signal class (dimensionless).
     ----------
-    background : array
-        Array containing [wavelength, background].
     """
 
     def crop_edges(self, crop_px):
@@ -88,6 +86,7 @@ class CommonLumi:
             """
             return signal - bkg
 
+        background_metadata = self.metadata.Signal.background
         if background is not None:
             if (background[0]).all() == (self.axes_manager.signal_axes[0].axis).all():
                 bkg = background[1]
@@ -96,15 +95,15 @@ class CommonLumi:
                 raise ValueError('The background x axis provided as external argument is does not match the signal '
                                  'wavelength x axis values.')
         else:
-            if self.background is not None:
-                if (self.background[0]).all() == (self.axes_manager.signal_axes[0].axis).all():
-                    bkg = self.background[1]
+            if background_metadata is not None:
+                if (background_metadata[0]).all() == (self.axes_manager.signal_axes[0].axis).all():
+                    bkg = background_metadata[1]
 
                 else:
                     raise ValueError('The background x axis wavelength values from the signal.background axis do not '
                                      'match the signal wavelength x axis values.')
             else:
-                raise ValueError('No background defined on the signal.background NOR as an input of this function.')
+                raise ValueError('No background defined on the Signal.background metadata NOR as an input of this function.')
 
         if not inplace:
             self_subtracted = self.map(subtract_self, bkg=bkg, inplace=False)

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -26,16 +26,12 @@ from lumispy.signals.common_luminescence import CommonLumi
 
 class LumiSpectrum(Signal1D, CommonLumi):
     """General 1D Luminescence signal class.
-    ----------
-    background : array
-        Array containing [wavelength, background].
     """
     _signal_type = "Luminescence"
     _signal_dimension = 1
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.background = None
 
 
 class LazyLumiSpectrum(LazySignal, LumiSpectrum):


### PR DESCRIPTION
This is to make it work with the hyperspy io_plugin to be implemented soon, as decribed in #26.