### PR TITLE
Energy conversion of signal axis

### DIFF
--- a/lumispy/__init__.py
+++ b/lumispy/__init__.py
@@ -43,6 +43,8 @@ from .signals.luminescence_transient import LazyLumiTransient
 
 from .io import load
 
+from .utils.axes import *
+
 from . import release_info
 
 __version__ = release_info.version

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -39,20 +39,25 @@ class LumiSpectrum(Signal1D, CommonLumi):
         super().__init__(*args, **kwargs)
 
 
-    def to_eV(self,inplace=True):
+    def to_eV(self,inplace=True,jacobian=True):
         """Converts signal axis of 1D signal to non-linear energy axis (eV) 
         using wavelength dependent permittivity of air. Assumes WL in units of 
         nm unless the axis units are specifically set to µm.
         
         The intensity is converted from counts/nm (counts/µm) to counts/meV by 
         doing a Jacobian transformation, see e.g. Wang and Townsend, J. Lumin. 
-        142, 202 (2013).
+        142, 202 (2013), which ensures that integrated signals are correct also
+        in the energy domain.
         
         Input parameters
         ----------------
         inplace : boolean
             If `False`, a new signal object is created and returned. Otherwise 
             (default) the operation is performed on the existing signal object.
+        jacobian : boolean
+            The default is to do the Jacobian transformation (recommended at 
+            least for luminescence signals), but the transformation can be
+            suppressed by setting this option to `False`.
         
         Example
         -------
@@ -63,28 +68,34 @@ class LumiSpectrum(Signal1D, CommonLumi):
         
         Note
         ----
-        Setting non linear scale instead of offset and scale work only for 
-        the non_uniform_axis branch of hyperspy.
+        Using a non-linear axis works only for the non_uniform_axis development
+        branch of hyperspy.
     
         """
         
         # Check if non_uniform_axis is available in hyperspy version
         if not 'axis' in getfullargspec(DataAxis)[0]:
-            raise NotImplementedError('Conversion to energy axis works only if '
-                                'the non_uniform_axis branch of hyperspy is used.')
+            raise NotImplementedError('Conversion to energy axis works only '
+                         'if the non_uniform_axis branch of hyperspy is used.')
 
         evaxis,factor = axis2eV(self.axes_manager.signal_axes[0])
         
         # in place conversion
         if inplace:
-            self.data = data2eV(self.isig[::-1].data, factor,
+            if jacobian:
+                self.data = data2eV(self.isig[::-1].data, factor,
                             self.axes_manager.signal_axes[0].axis, evaxis.axis)
+            else:
+                self.data = self.isig[::-1].data
             self.axes_manager.remove(-1)
             self.axes_manager._axes.append(evaxis)
         # create and return new signal
         else:
-            s2data = data2eV(self.isig[::-1].data, factor,
+            if jacobian:
+                s2data = data2eV(self.isig[::-1].data, factor,
                             self.axes_manager.signal_axes[0].axis, evaxis.axis)
+            else:
+                s2data = self.isig[::-1].data
             if self.data.ndim == 1:
                 s2 = Signal1D(s2data, axes=(evaxis.get_axis_dictionary(),))
             elif self.data.ndim == 2:

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -38,21 +38,28 @@ class LumiSpectrum(Signal1D, CommonLumi):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+
     def to_eV(self,inplace=True):
-        """Converts signal axis of 1Dsignal to non-linear energy axis (eV) 
+        """Converts signal axis of 1D signal to non-linear energy axis (eV) 
         using wavelength dependent permittivity of air. Assumes WL in units of 
         nm unless the axis units are specifically set to µm.
         
         The intensity is converted from counts/nm (counts/µm) to counts/meV by 
-        doing a Jacobian transformation, see e.g. Wang and Townsend, J. Lumin. 142, 
-        202 (2013).
-    
+        doing a Jacobian transformation, see e.g. Wang and Townsend, J. Lumin. 
+        142, 202 (2013).
         
         Input parameters
         ----------------
         inplace : boolean
             If `False`, a new signal object is created and returned. Otherwise 
             (default) the operation is performed on the existing signal object.
+        
+        Example
+        -------
+        > import numpy as np
+        > from lumispy import LumiSpectrum
+        > S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
+        > S1.to_eV()
         
         Note
         ----
@@ -68,11 +75,13 @@ class LumiSpectrum(Signal1D, CommonLumi):
 
         evaxis,factor = axis2eV(self.axes_manager.signal_axes[0])
         
+        # in place conversion
         if inplace:
             self.data = data2eV(self.isig[::-1].data, factor,
                             self.axes_manager.signal_axes[0].axis, evaxis.axis)
             self.axes_manager.remove(-1)
             self.axes_manager._axes.append(evaxis)
+        # create and return new signal
         else:
             s2data = data2eV(self.isig[::-1].data, factor,
                             self.axes_manager.signal_axes[0].axis, evaxis.axis)
@@ -90,8 +99,6 @@ class LumiSpectrum(Signal1D, CommonLumi):
             s2.set_signal_type(self.metadata.Signal.signal_type)
             s2.metadata = self.metadata
             return s2
-            # Use current signal object instead of Signal1D
-            # Copy metadata to new signal object
 
 
 class LazyLumiSpectrum(LazySignal, LumiSpectrum):

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -87,6 +87,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
                      (self.axes_manager.navigation_axes[1].get_axis_dictionary(),
                      self.axes_manager.navigation_axes[0].get_axis_dictionary(),
                      evaxis.get_axis_dictionary(), ))
+            s2.set_signal_type(self.metadata.Signal.signal_type)
             s2.metadata = self.metadata
             return s2
             # Use current signal object instead of Signal1D

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -87,6 +87,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
                      (self.axes_manager.navigation_axes[1].get_axis_dictionary(),
                      self.axes_manager.navigation_axes[0].get_axis_dictionary(),
                      evaxis.get_axis_dictionary(), ))
+            s2.metadata = self.metadata
             return s2
             # Use current signal object instead of Signal1D
             # Copy metadata to new signal object

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -21,8 +21,13 @@
 
 from hyperspy._signals.signal1d import Signal1D
 from hyperspy._signals.lazy import LazySignal
+from hyperspy.axes import DataAxis
 from lumispy.signals.common_luminescence import CommonLumi
+from lumispy.utils.axes import axis2eV
+from lumispy.utils.axes import data2eV
 
+
+from inspect import getfullargspec
 
 class LumiSpectrum(Signal1D, CommonLumi):
     """General 1D Luminescence signal class.
@@ -32,6 +37,59 @@ class LumiSpectrum(Signal1D, CommonLumi):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+    def to_eV(self,inplace=True):
+        """Converts signal axis of 1Dsignal to non-linear energy axis (eV) 
+        using wavelength dependent permittivity of air. Assumes WL in units of 
+        nm unless the axis units are specifically set to µm.
+        
+        The intensity is converted from counts/nm (counts/µm) to counts/meV by 
+        doing a Jacobian transformation, see e.g. Wang and Townsend, J. Lumin. 142, 
+        202 (2013).
+    
+        
+        Input parameters
+        ----------------
+        inplace : boolean
+            If `False`, a new signal object is created and returned. Otherwise 
+            (default) the operation is performed on the existing signal object.
+        
+        Note
+        ----
+        Setting non linear scale instead of offset and scale work only for 
+        the non_uniform_axis branch of hyperspy.
+    
+        """
+        
+        # Check if non_uniform_axis is available in hyperspy version
+        if not 'axis' in getfullargspec(DataAxis)[0]:
+            raise NotImplementedError('Conversion to energy axis works only if '
+                                'the non_uniform_axis branch of hyperspy is used.')
+
+        evaxis,factor = axis2eV(self.axes_manager.signal_axes[0])
+        
+        if inplace:
+            self.data = data2eV(self.isig[::-1].data, factor,
+                            self.axes_manager.signal_axes[0].axis, evaxis.axis)
+            self.axes_manager.remove(-1)
+            self.axes_manager._axes.append(evaxis)
+        else:
+            s2data = data2eV(self.isig[::-1].data, factor,
+                            self.axes_manager.signal_axes[0].axis, evaxis.axis)
+            if self.data.ndim == 1:
+                s2 = Signal1D(s2data, axes=(evaxis.get_axis_dictionary(),))
+            elif self.data.ndim == 2:
+                s2 = Signal1D(s2data, axes=
+                     (self.axes_manager.navigation_axes[0].get_axis_dictionary(),
+                     evaxis.get_axis_dictionary(), ))
+            else:
+                s2 = Signal1D(s2data, axes=
+                     (self.axes_manager.navigation_axes[1].get_axis_dictionary(),
+                     self.axes_manager.navigation_axes[0].get_axis_dictionary(),
+                     evaxis.get_axis_dictionary(), ))
+            return s2
+            # Use current signal object instead of Signal1D
+            # Copy metadata to new signal object
 
 
 class LazyLumiSpectrum(LazySignal, LumiSpectrum):

--- a/lumispy/tests/test_axis-conversion.py
+++ b/lumispy/tests/test_axis-conversion.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+from numpy import arange
+from numpy import ones
+from pytest import raises
+from numpy.testing import assert_allclose
+
+from hyperspy.axes import DataAxis
+from lumispy import LumiSpectrum
+from lumispy import CLSEMSpectrum
+from lumispy.utils.axes import *
+
+
+
+def test_nm2eV():
+    wl = arange(300,400,90)
+    en = nm2eV(wl)
+    assert_allclose(en[0],4.13160202)
+    assert_allclose(en[-1],3.17818160)
+    
+def test_eV2nm():
+    en = arange(1,2,0.8)
+    wl = eV2nm(en)
+    assert_allclose(wl[0],1239.50284)
+    assert_allclose(wl[-1],688.611116)
+    
+def test_axes2eV():
+    axis = DataAxis(axis = arange(200,400,10))
+    axis2 = DataAxis(axis = arange(0.2,0.400,0.01),units='µm')
+    axis3 = DataAxis(axis = arange(1,2,0.1),units='eV')
+    evaxis,factor = axis2eV(axis)
+    evaxis2,factor2 = axis2eV(axis2)
+    raises(AttributeError,axis2eV,axis3)
+    assert factor == 1e6
+    assert factor2 == 1e3
+    assert evaxis.name == 'Energy'
+    assert evaxis.units == 'eV'
+    assert not evaxis.navigate
+    assert evaxis2.units == 'eV'
+    assert evaxis2.size == 20
+    assert_allclose(evaxis.axis[0],evaxis2.axis[0])
+    assert_allclose(evaxis.axis[-1],evaxis2.axis[-1])
+    assert_allclose(evaxis.axis[0],3.1781816)
+
+def test_data2eV():
+    data = 100*ones(20)
+    factor = 1e6
+    ax0 = arange(200,400,10)
+    evaxis = nm2eV(ax0)
+    evdata = data2eV(data,factor,ax0,evaxis)
+    assert_allclose(evdata[-1],12.27066795)
+
+def test_to_eV():
+    axis = DataAxis(axis = arange(200,400,10))
+    data = ones(20)
+    S1 = LumiSpectrum(data, axes=(axis.get_axis_dictionary(), ))
+    S1.to_eV()
+    axis.units = 'µm'
+    axis.axis = axis.axis / 1000
+    data *= 1000
+    S2 = CLSEMSpectrum(data, axes=(axis.get_axis_dictionary(), ))
+    S3 = S2.to_eV(inplace=False)
+    assert S1.axes_manager[0].units == 'eV'
+    assert S3.axes_manager[0].name == 'Energy'
+    assert S3.axes_manager[0].size == 20
+    assert S1.axes_manager[0].axis[0] == S3.axes_manager[0].axis[0]
+    assert_allclose(S1.data,S3.data,5e-4)

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -33,25 +33,22 @@ def _n_air(wl):
     According to `E.R. Peck and K. Reeder. Dispersion of air, 
     J. Opt. Soc. Am. 62, 958-962 (1972).`
     """
-
     wl = wl / 1000
     return 1 + 806051e-10 + 2480990e-8/(132274e-3 - 1/wl**2) + \
            174557e-9/(3932957e-5 - 1/wl**2)
 
 
 def nm2eV(x):
-    """Converts wavelength to energy using wavelength-dependent permittivity of 
-    air.
+    """Converts wavelength (nm) to energy (eV) using wavelength-dependent 
+    permittivity of air.
     """
-
     return 1e9 * c.h * c.c / (c.e * _n_air(x) * x)
 
 
 def eV2nm(x):
-    """Converts energy to wavelength using wavelength-dependent permittivity of 
-    air.
+    """Converts energy (eV) to wavelength (nm) using wavelength-dependent 
+    permittivity of air.
     """
-
     wl = 1239.5/x # approximate WL to obtain permittivity
     return 1e9 * c.h * c.c / (c.e * _n_air(wl) * x)
 
@@ -61,7 +58,6 @@ def axis2eV(ax0):
     of air. Assumes WL in units of nm 
     unless the axis units are specifically set to µm.
     """
-
     if ax0.units == 'eV':
         raise AttributeError('Signal unit is already eV.')
     # transform axis, invert direction
@@ -84,4 +80,3 @@ def data2eV(data, factor, ax0, evaxis):
     """
     return data * factor * c.h * c.c / (c.e * _n_air(ax0[::-1])
            * evaxis**2)
-

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -20,10 +20,10 @@ import numpy as np
 import scipy.constants as c
 
 from hyperspy.axes import DataAxis
-from hyperspy.signals import Signal1D
 
-from inspect import getfullargspec # not needed in the future
-
+#
+# This file contains function needed for signal axis conversion
+#
 
 def _n_air(wl):
     """Refractive index of air as a function of WL in nm.

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy as np
+import scipy.constants as c
+
+from hyperspy.axes import DataAxis
+from hyperspy.signals import Signal1D
+
+from inspect import getfullargspec
+
+
+def _n_air(wl):
+    """Refractive index of air as a function of WL in nm.
+
+    This analytical function is correct for the range 185-1700 nm.
+
+    According to `E.R. Peck and K. Reeder. Dispersion of air, 
+    J. Opt. Soc. Am. 62, 958-962 (1972).`
+    """
+
+    wl = wl / 1000
+    return 1 + 806051e-10 + 2480990e-8/(132274e-3 - 1/wl**2) + \
+           174557e-9/(3932957e-5 - 1/wl**2)
+
+
+def nm2eV(x):
+    """Converts wavelength to energy using wavelength-dependent permittivity of 
+    air.
+    """
+
+    return 1e9 * c.h * c.c / (c.e * _n_air(x) * x)
+
+
+def eV2nm(x):
+    """Converts energy to wavelength using wavelength-dependent permittivity of 
+    air.
+    """
+
+    wl = 1239.5/x # approximate WL to obtain permittivity
+    return 1e9 * c.h * c.c / (c.e * _n_air(wl) * x)
+
+def to_eV(s):
+    """Creates new signal object with signal axis converted to eV (using 
+    wavelength dependent permittivity of air). Assumes WL in units of nm 
+    unless the axis units are specifically set to µm.
+    
+    The intensity is converted from counts/nm (counts/µm) to counts/meV by 
+    doing a Jacobian transformation, see e.g. Wang and Townsend, J. Lumin. 142, 
+    202 (2013).
+
+    
+    Input parameters
+    ----------------
+    s : signal object
+    
+    Returns
+    -------
+    New signal object with energy axis as new signal axis, but same navigation 
+    axis and data.
+    
+    Note
+    ----
+    Setting non linear scale instead of offset and scale work only for 
+    the non_uniform_axis branch of hyperspy.
+
+    """
+
+    # Check if non_uniform_axis is available in hyperspy version
+    if not 'axis' in getfullargspec(DataAxis)[0]:
+        raise NotImplementedError('Conversion to energy axis works only if '
+                            'the non_uniform_axis branch of hyperspy is used.')
+        
+    ax0 = s.axes_manager.signal_axes[0]
+    if ax0.units == 'eV':
+        raise AttributeError('Signal unit is already eV.')
+    # transform axis, invert direction
+    if ax0.units == 'µm':
+        evaxis=nm2eV(1000*ax0.axis)[::-1]
+        factor = 1e3 # correction factor for intensity
+    else:
+        evaxis=nm2eV(ax0.axis)[::-1]
+        factor = 1e6
+    axis = DataAxis(axis = evaxis, name = 'Energy', units = 'eV', 
+               navigate=False)
+    # invert direction for data and do Jacobian transformation so that 
+    # integrated signals are correct
+    s2data = s.isig[::-1].data * factor * c.h * c.c / (c.e * 
+             _n_air(ax0.axis[::-1]) * evaxis**2)
+    if s.data.ndim == 1:
+        s2 = Signal1D(s2data, axes=(axis.get_axis_dictionary(),))
+    elif s.data.ndim == 2:
+        s2 = Signal1D(s2data, axes=
+             (s.axes_manager.navigation_axes[0].get_axis_dictionary(),
+             axis.get_axis_dictionary(), ))
+    else:
+        s2 = Signal1D(s2data, axes=
+             (s.axes_manager.navigation_axes[1].get_axis_dictionary(),
+             s.axes_manager.navigation_axes[0].get_axis_dictionary(),
+             axis.get_axis_dictionary(), ))
+    return s2


### PR DESCRIPTION
### Description of the change
As discussed in #14, I implemented and extended my function to convert the signal axis to energy. Includes wavelength dependent permittivity of air (minor correction for very precise data). Corrects intensities so that integrals are correct. Defaults to nm, but can handle µm if explicitly set.
Includes two helper functions `nm2eV` and `eV2nm` for back and forth calculation.

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] Raise error when non_uniform_axes functionality is not available from hyperspy,
- [X] Convert to object oriented function,
- [X] Add inplace functionality
- [x] Signal type and metadata for inplace=False
- [X] update docstring (if appropriate),
- [x] add tests,
- [x] ready for review.

