### PR TITLE
Add function to join several Signal1D objects along signal axes

### DIFF
--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -26,8 +26,8 @@ from lumispy.signals.common_luminescence import CommonLumi
 from lumispy.utils.axes import axis2eV
 from lumispy.utils.axes import data2eV
 
-
 from inspect import getfullargspec
+
 
 class LumiSpectrum(Signal1D, CommonLumi):
     """General 1D Luminescence signal class.

--- a/lumispy/tests/test_utils.py
+++ b/lumispy/tests/test_utils.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
+
+from numpy import ones
+from numpy.random import random
+from pytest import raises
+#from numpy.testing import assert_allclose
+
+from inspect import getfullargspec
+from hyperspy.signals import Signal1D
+from hyperspy.axes import DataAxis
+from lumispy import join_spectra
+
+def test_joinspectra():
+    s1 = Signal1D(ones(32))
+    s2 = Signal1D(ones(32)*2)
+    s2.axes_manager.signal_axes[0].offset = 25
+    s = join_spectra([s1,s2],r=2)
+    assert s.data[-1] == 1
+    assert s.axes_manager.signal_axes[0].scale == 1
+    s = join_spectra([s1,s2],r=2,average=True)
+    assert s.data[-1] == 1
+    assert s.axes_manager.signal_axes[0].scale == 1
+    # Also check for (non-uniform) DataAxis
+    if 'axis' in getfullargspec(DataAxis)[0]:
+        s1.axes_manager.signal_axes[0].convert_to_non_uniform_axis()
+        s = join_spectra([s1,s2],r=2)
+        assert s.axes_manager.signal_axes[0].is_uniform == False
+        assert s.axes_manager.signal_axes[0].size == 57
+        assert s.axes_manager.signal_axes[0].axis[-1] == 56
+        assert s.data.size == 57
+        assert s.data[-1] == 1
+        s = join_spectra([s1,s2],r=2,average=True)
+        assert s.data.size == 57
+        assert s.axes_manager.signal_axes[0].size == 57
+    
+def test_joinspectra_Errors():
+    s1 = Signal1D(ones(32))
+    s2 = Signal1D(ones(32)*2)
+    s2.axes_manager.signal_axes[0].offset = 25
+    # Test that catch for r works
+    raises(ValueError,join_spectra,[s1,s2])
+    s2.axes_manager.signal_axes[0].offset = 35
+    # Test that overlap catch works
+    raises(ValueError,join_spectra,[s1,s2])
+    
+def test_joinspectra_FunctionalDA():
+    if 'axis' in getfullargspec(DataAxis)[0]:
+        s1 = Signal1D(ones(32))
+        s2 = Signal1D(ones(32)*2)
+        s2.axes_manager.signal_axes[0].offset = 25
+        s1.axes_manager.signal_axes[0].convert_to_functional_data_axis(expression='x**2')
+        s2.axes_manager.signal_axes[0].convert_to_functional_data_axis(expression='x**2')
+        s = join_spectra([s1,s2],r=2)
+        assert s.axes_manager.signal_axes[0].is_uniform == False
+        assert s.axes_manager.signal_axes[0].size == 57
+        assert s.axes_manager.signal_axes[0].axis[-1] == 3136
+        assert s.data.size == 57
+        assert s.data[-1] == 1
+        s = join_spectra([s1,s2],r=2,average=True)
+        assert s.data.size == 57
+        assert s.axes_manager.signal_axes[0].size == 57
+
+def test_joinspectra_Linescan():
+    s1 = Signal1D(random((4,64)))
+    s2 = Signal1D(random((4,64)))
+    s2.axes_manager.signal_axes[0].offset = 47
+    s = join_spectra([s1,s2],r=7,average=True)
+    assert s.axes_manager.signal_axes[0].size == 111

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -94,7 +94,8 @@ def join_spectra(S,r=50,average=False,kind='slinear'):
     """ Takes list of Signal1D objects and returns a single object with all
     spectra joined. Joins spectra at the center of the overlapping range.
     Scales spectra by a factor determined as average over the range
-    `center -/+ r` pixels. Axes
+    `center -/+ r` pixels. Works both for uniform and non-uniform axes 
+    (FunctionalDataAxis is converted into a non-uniform DataAxis).
     
     Parameters
     ----------
@@ -115,6 +116,15 @@ def join_spectra(S,r=50,average=False,kind='slinear'):
     -------
     A new Signal1D object containing the joined spectra (properties are copied
     from first spectrum).
+    
+    Examples
+    --------
+    
+    >>> s1 = hs.signals.Signal1D(np.ones(32))
+    >>> s2 = hs.signals.Signal1D(np.ones(32)*2)
+    >>> s2.axes_manager.signal_axes[0].offset = 25
+    >>> lum.join_spectra([s1,s2],r=2)
+    <Signal1D, title: , dimensions: (|57)>
     """
     
     import numpy as np
@@ -145,7 +155,7 @@ def join_spectra(S,r=50,average=False,kind='slinear'):
         # Test that r is not too large
         if (axis.value2index(omax) - ind1) <= r:
             raise ValueError("`r` is too large")
-        # calculate mean deviation over defined range ignoring nan or zero values
+        # calculate mean deviation over defined range ignoring nan/zero values
         init = np.empty(S2.isig[ind2-r:ind2+r].data.shape)
         init[:] = np.nan
         factor = np.nanmean(np.divide(S1.isig[ind1-r:ind1+r].data,
@@ -154,9 +164,11 @@ def join_spectra(S,r=50,average=False,kind='slinear'):
         S2.data = (S2.data.T * factor).T # scale 2nd spectrum by factor
         
         # for UniformDataAxis
-        if not 'axis' in getfullargspec(DataAxis)[0] or axis.is_uniform:
+        if (not 'axis' in getfullargspec(DataAxis)[0]) or (axis.is_uniform \
+           and axis2.is_uniform):
             # join axis vectors  
-            axis.size = axis.axis[:ind1+1].size + np.floor((axis2.axis[-1] - axis.axis[ind1])/axis.scale)
+            axis.size = axis.axis[:ind1+1].size + np.floor((axis2.axis[-1]
+                        - axis.axis[ind1])/axis.scale)
             # join data vectors interpolating to a common uniform axis
             if average: # average over range
                 ind2r = axis2.value2index(axis.axis[ind1-r])
@@ -172,8 +184,8 @@ def join_spectra(S,r=50,average=False,kind='slinear'):
                 S1.data = np.hstack((S1.isig[:ind1+1].data,
                           f(axis.axis[ind1+1:])))
         else: # for DataAxis/FunctionalDataAxis (non uniform)
-            # convert FunctionalDataAxes to DataAxes
-            if hasattr(axis,'expression'):
+            # convert FunctionalDataAxes or UniformDataAxis to DataAxes
+            if hasattr(axis,'expression') or axis.is_uniform:
                 axis.convert_to_non_uniform_axis()
             if hasattr(axis2,'expression'):
                 axis2.convert_to_non_uniform_axis()

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -156,7 +156,7 @@ def join_spectra(S,r=50,average=False,kind='slinear'):
         # for UniformDataAxis
         if not 'axis' in getfullargspec(DataAxis)[0] or axis.is_uniform:
             # join axis vectors  
-            axis.size = axis.axis[:ind1].size + np.floor((axis2.axis[-1] - axis.axis[ind1])/axis.scale)
+            axis.size = axis.axis[:ind1+1].size + np.floor((axis2.axis[-1] - axis.axis[ind1])/axis.scale)
             # join data vectors interpolating to a common uniform axis
             if average: # average over range
                 ind2r = axis2.value2index(axis.axis[ind1-r])
@@ -179,10 +179,11 @@ def join_spectra(S,r=50,average=False,kind='slinear'):
                 axis2.convert_to_non_uniform_axis()
             # join axis vectors  
             axis.axis = np.hstack((axis.axis[:ind1],axis2.axis[ind2:]))
+            axis.size = axis.axis.size
             if average: # average over range
                 S1.data = np.hstack((S1.isig[:ind1-r].data,
                           np.mean([S1.isig[ind1-r:ind1+r].data,
-                          S2.isig[ind2-r:ind2+r]],axis=0),
+                          S2.isig[ind2-r:ind2+r].data],axis=0),
                           S2.isig[ind2+r:]))
             else: # just join at center of overlap
                 S1.data = np.hstack((S1.isig[:ind1].data,


### PR DESCRIPTION
Addes `join_spectra` function to `utils/axes`, which allows to join spectra with partially overlapping signal axes.

### Progress of the PR
- [X] Change implemented,
- [x] update docstring (if appropriate),
- [x] add tests,
- [x] ready for review.

### Usage
> S = lum.join_spectra([S1,S2])