### PR TITLE
Test against hyperspy release or dev

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,6 +39,12 @@ jobs:
         shell: bash
         run: |
           pip install ${{ env.PIP_ARGS }} .'${{ matrix.PIP_SELECTOR }}'
+
+      - name: Install (HyperSpy dev)
+        # Test against the hyperspy `non_uniform_axes` branch
+        if: ${{ matrix.PYTEST_ARGS_COVERAGE }} 
+        shell: bash
+        run: |
           pip install https://github.com/hyperspy/hyperspy/archive/non_uniform_axes.zip
 
       - name: Run test suite

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # LumiSpy
 
 [![Build Status](https://dev.azure.com/Lumispy/lumispy/_apis/build/status/LumiSpy.lumispy?branchName=master)](https://dev.azure.com/Lumispy/lumispy/_build/latest?definitionId=3&branchName=master)
-[![Build Status](https://travis-ci.org/LumiSpy/lumispy.svg?branch=master)](https://travis-ci.org/LumiSpy/lumispy)
 ![Tests](https://github.com/lumispy/lumispy/workflows/Tests/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/LumiSpy/lumispy/badge.svg?branch=master)](https://coveralls.io/github/LumiSpy/lumispy?branch=master)
 


### PR DESCRIPTION
Run test suite with the `non-uniform-axis` branch of hyperspy only for the coverage build. Other build use the release version of hyperspy.