### PR TITLE
Class hierarchy update

### DIFF
--- a/lumispy/hyperspy_extension.yaml
+++ b/lumispy/hyperspy_extension.yaml
@@ -37,7 +37,7 @@ signals:
   CLSpectrum:
     signal_type: CL
     signal_type_aliases:
-      - CL
+      - CLSpectrum
       - cathodoluminescence
     signal_dimension: 1
     dtype: real
@@ -46,7 +46,7 @@ signals:
   LazyCLSpectrum:
     signal_type: CL
     signal_type_aliases:
-      - CL
+      - CLSpectrum
       - cathodoluminescence
     signal_dimension: 1
     dtype: real
@@ -56,7 +56,7 @@ signals:
   ELSpectrum:
     signal_type: EL
     signal_type_aliases:
-      - EL
+      - ELSpectrum
       - electroluminescence
     signal_dimension: 1
     dtype: real
@@ -65,7 +65,7 @@ signals:
   LazyELSpectrum:
     signal_type: EL
     signal_type_aliases:
-      - EL
+      - ELSpectrum
       - electroluminescence
     signal_dimension: 1
     dtype: real
@@ -75,7 +75,7 @@ signals:
   PLSpectrum:
     signal_type: PL
     signal_type_aliases:
-      - PL
+      - PLSpectrum
       - photoluminescence
     signal_dimension: 1
     dtype: real
@@ -84,7 +84,7 @@ signals:
   LazyPLSpectrum:
     signal_type: PL
     signal_type_aliases:
-      - PL
+      - PLSpectrum
       - photoluminescence
     signal_dimension: 1
     dtype: real
@@ -134,6 +134,7 @@ signals:
     signal_type_aliases:
       - TRLumi
       - TR luminescence
+      - time-resolved luminescence
     signal_dimension: 2
     dtype: real
     lazy: False
@@ -141,9 +142,11 @@ signals:
   LazyLumiTransient:
     signal_type: Luminescence
     signal_type_aliases:
-      - TR Luminescence
       - TRLumi
+      - TR luminescence
+      - time-resolved luminescence
     signal_dimension: 2
     dtype: real
     lazy: True
     module: lumispy.signals.luminescence_transient
+

--- a/lumispy/hyperspy_extension.yaml
+++ b/lumispy/hyperspy_extension.yaml
@@ -150,3 +150,40 @@ signals:
     lazy: True
     module: lumispy.signals.luminescence_transient
 
+  CLTransient:
+    signal_type: TRCL
+    signal_type_aliases:
+      - TR cathodoluminescence
+      - time-resolved cathodoluminescence
+    signal_dimension: 2
+    dtype: real
+    lazy: False
+    module: lumispy.signals.cl_transient
+  LazyCLTransient:
+    signal_type: TRCL
+    signal_type_aliases:
+      - TR cathodoluminescence
+      - time-resolved cathodoluminescence
+    signal_dimension: 2
+    dtype: real
+    lazy: True
+    module: lumispy.signals.cl_transient
+
+  PLTransient:
+    signal_type: TRPL
+    signal_type_aliases:
+      - TR photoluminescence
+      - time-resolved photoluminescence
+    signal_dimension: 2
+    dtype: real
+    lazy: False
+    module: lumispy.signals.pl_transient
+  LazyPLTransient:
+    signal_type: TRPL
+    signal_type_aliases:
+      - TR photoluminescence
+      - time-resolved photoluminescence
+    signal_dimension: 2
+    dtype: real
+    lazy: True
+    module: lumispy.signals.pl_transient

--- a/lumispy/signals/__init__.py
+++ b/lumispy/signals/__init__.py
@@ -23,6 +23,8 @@ from .cl_spectrum import CLSTEMSpectrum, LazyCLSTEMSpectrum
 from .pl_spectrum import PLSpectrum, LazyPLSpectrum
 from .el_spectrum import ELSpectrum, LazyELSpectrum
 from .luminescence_transient import LumiTransient, LazyLumiTransient
+from .cl_transient import CLTransient, LazyCLTransient
+from .pl_transient import PLTransient, LazyPLTransient
 
 
 __all__ = [
@@ -40,4 +42,8 @@ __all__ = [
     "LazyELSpectrum",
     "LumiTransient",
     "LazyLumiTransient",
+    "CLTransient",
+    "LazyCLTransient",
+    "PLTransient",
+    "LazyPLTransient",
     ]

--- a/lumispy/signals/cl_transient.py
+++ b/lumispy/signals/cl_transient.py
@@ -22,19 +22,19 @@
 from hyperspy.signals import Signal2D
 from hyperspy._signals.lazy import LazySignal
 
-from lumispy.signals.common_luminescence import CommonLumi
+from lumispy.signals.luminescence_transient import LumiTransient
 
 
-class LumiTransient(Signal2D, CommonLumi):
-    """General 2D luminescence signal class (transient/time resolved).
+class CLTransient(LumiTransient):
+    """CL 2D luminescence signal class (transient/time resolved).
     """
-    _signal_type = "Luminescence"
+    _signal_type = "TRCL"
     _signal_dimension = 2
 
     pass
 
 
-class LazyLumiTransient(LazySignal, LumiTransient):
+class LazyCLTransient(LazySignal, CLTransient):
     _lazy = True
 
     pass

--- a/lumispy/signals/pl_transient.py
+++ b/lumispy/signals/pl_transient.py
@@ -22,19 +22,19 @@
 from hyperspy.signals import Signal2D
 from hyperspy._signals.lazy import LazySignal
 
-from lumispy.signals.common_luminescence import CommonLumi
+from lumispy.signals.luminescence_transient import LumiTransient
 
 
-class LumiTransient(Signal2D, CommonLumi):
-    """General 2D luminescence signal class (transient/time resolved).
+class PLTransient(LumiTransient):
+    """PL 2D luminescence signal class (transient/time resolved).
     """
-    _signal_type = "Luminescence"
+    _signal_type = "TRPL"
     _signal_dimension = 2
 
     pass
 
 
-class LazyLumiTransient(LazySignal, LumiTransient):
+class LazyPLTransient(LazySignal, PLTransient):
     _lazy = True
 
     pass

--- a/lumispy/tests/test_signal_registration.py
+++ b/lumispy/tests/test_signal_registration.py
@@ -21,16 +21,19 @@ from numpy import arange
 
 from hyperspy.signals import Signal1D, Signal2D
 
-from lumispy.signals import (LumiSpectrum, CLSpectrum, CLSEMSpectrum, CLSTEMSpectrum,
-                     PLSpectrum, ELSpectrum, LumiTransient, LazyLumiSpectrum,
-                     LazyCLSpectrum, LazyCLSEMSpectrum, LazyCLSTEMSpectrum,
-                     LazyPLSpectrum, LazyELSpectrum, LazyLumiTransient)
+from lumispy.signals import (LumiSpectrum, CLSpectrum, CLSEMSpectrum,
+                     CLSTEMSpectrum, PLSpectrum, ELSpectrum, LumiTransient,
+                     CLTransient, PLTransient, LazyLumiSpectrum, LazyCLSpectrum,
+                     LazyCLSEMSpectrum, LazyCLSTEMSpectrum, LazyPLSpectrum, 
+                     LazyELSpectrum, LazyLumiTransient, LazyCLTransient,
+                     LazyPLTransient)
 
 signal1d_class_list = [LumiSpectrum, CLSpectrum, CLSEMSpectrum, CLSTEMSpectrum,
                        PLSpectrum, ELSpectrum, LazyLumiSpectrum,
                        LazyCLSpectrum, LazyCLSEMSpectrum, LazyCLSTEMSpectrum,
                        LazyPLSpectrum, LazyELSpectrum]
-signal2d_class_list = [LumiTransient, LazyLumiTransient]
+signal2d_class_list = [LumiTransient, CLTransient, PLTransient, 
+                       LazyLumiTransient, LazyCLTransient, LazyPLTransient]
 
 
 @pytest.mark.parametrize("signal_class", signal1d_class_list)


### PR DESCRIPTION
### Description of the change
Corrected some aliases of the different LumiSpy classes, e.g. `PL` as alias for `PL` makes no sense
(I realized that in https://github.com/hyperspy/hyperspy-extensions-list/pull/6).

Added the remaining Transient classes we defined in #5, `CLTransient` and `PLTransient`, already from the metadata point of view there will be a difference and I imagine that some methods could also be instrument depenent.

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [X] update docstring (if appropriate),
- [X] add tests,
- [X] ready for review.
