### PR TITLE
Fix failing test

### DIFF
--- a/lumispy/signals/cl_spectrum.py
+++ b/lumispy/signals/cl_spectrum.py
@@ -109,7 +109,7 @@ class CLSpectrum(LumiSpectrum):
                     In the form of an array of pairwise elements [[peak1_x, peak1_width], [peak2_x, peak2_width],...]
                     in the units of the signal axis. It creates a signal_mask protecting the peak regions.
                     To be used instead of `signal_mask`.
-                
+
                 Returns
                 ----------
                 :return: None or CLSpectrum
@@ -146,14 +146,12 @@ class CLSEMSpectrum(CLSpectrum):
 
         """
 
-        # Avoid correcting for this shift twice (first time it fails, so except
-        # block runs. Second time, try succeeds, so except block is skipped):
-        try:
-            self.metadata.Signal.grating_corrected == True
-        except AttributeError:
+        # Don't correct for grating shift if this is already corrected
+        if self.metadata.get_item('Signal.grating_corrected') is True:
+            raise RuntimeError("The grating shift has already been corrected.")
+        else:
             # Get all relevant parameters
-            nx = self.axes_manager.navigation_shape[0]
-            ny = self.axes_manager.navigation_shape[1]
+            (nx, ny) = self.axes_manager.navigation_shape[:2]
             fov = sem_magnification
 
             # Correction of the Wavelength Shift along the X-Axis
@@ -168,8 +166,6 @@ class CLSEMSpectrum(CLSpectrum):
 
             # Store modification in metadata
             self.metadata.set_item("Signal.grating_corrected", True)
-        else:
-            raise Exception("You already corrected for the grating shift.")
 
 
 class LazyCLSEMSpectrum(LazySignal, CLSEMSpectrum):

--- a/lumispy/tests/utils/test_io.py
+++ b/lumispy/tests/utils/test_io.py
@@ -19,7 +19,6 @@
 from pytest import raises, mark
 from numpy import loadtxt, arange
 from numpy.testing import assert_array_equal
-import tempfile
 
 from hyperspy.signals import Signal2D
 
@@ -62,8 +61,8 @@ def test_to_array_linescan(axes, transpose):
 def test_savetxt_spectrum(axes, tmp_path):
     s = LumiSpectrum(arange(5))
     fname = tmp_path / 'test.txt'
-    s.savetxt('fname', axes=axes)
-    s2 = loadtxt('fname')
+    s.savetxt(fname, axes=axes)
+    s2 = loadtxt(fname)
     if axes:
         assert_array_equal(s.axes_manager[0].axis,s2[:,0])
     else:
@@ -75,8 +74,8 @@ def test_savetxt_navigate1D(axes, tmp_path):
     s = LumiSpectrum(arange(5))
     s.axes_manager[0].navigate=True
     fname = tmp_path / 'test.txt'
-    s.savetxt('fname', axes=axes)
-    s2 = loadtxt('fname')
+    s.savetxt(fname, axes=axes)
+    s2 = loadtxt(fname)
     if axes:
         assert_array_equal(s.axes_manager[0].axis,s2[:,0])
     else:
@@ -88,8 +87,8 @@ def test_savetxt_navigate1D(axes, tmp_path):
 def test_savetxt_linescan(axes, transpose, tmp_path):
     s = LumiSpectrum(arange(20).reshape((4,5)))
     fname = tmp_path / 'test.txt'
-    s.savetxt('fname', axes=axes, transpose=transpose)
-    s2 = loadtxt('fname')
+    s.savetxt(fname, axes=axes, transpose=transpose)
+    s2 = loadtxt(fname)
     if axes:
         if transpose:
             assert_array_equal(s.axes_manager[0].axis,s2[0,1:])
@@ -111,8 +110,8 @@ def test_savetxt_linescan(axes, transpose, tmp_path):
 def test_savetxt_signal2D(axes, transpose, tmp_path):
     s = Signal2D(arange(20).reshape((4,5)))
     fname = tmp_path / 'test.txt'
-    savetxt(s, 'fname', axes=axes, transpose=transpose)
-    s2 = loadtxt('fname')
+    savetxt(s, fname, axes=axes, transpose=transpose)
+    s2 = loadtxt(fname)
     if axes:
         if transpose:
             assert_array_equal(s.axes_manager[1].axis,s2[0,1:])
@@ -136,8 +135,8 @@ def test_savetxt_navigate2D(axes, transpose, tmp_path):
     s.axes_manager[0].navigate=True
     s.axes_manager[1].navigate=True
     fname = tmp_path / 'test.txt'
-    savetxt(s, 'fname', axes=axes, transpose=transpose)
-    s2 = loadtxt('fname')
+    savetxt(s, fname, axes=axes, transpose=transpose)
+    s2 = loadtxt(fname)
     if axes:
         if transpose:
             assert_array_equal(s.axes_manager[1].axis,s2[0,1:])
@@ -158,7 +157,7 @@ def test_savetxt_dimension_error(tmp_path):
     s = LumiSpectrum(arange(60).reshape((3,4,5)))
     fname = tmp_path / 'test.txt'
     with raises(NotImplementedError):
-        s.savetxt('fname')
+        s.savetxt(fname)
 
 def test_to_array_dimension_error():
     s = LumiSpectrum(arange(60).reshape((3,4,5)))


### PR DESCRIPTION
HyperSpy 1.6.2 breaks `correct_grating_shift`, because of a regression in `shift1D` - see https://github.com/hyperspy/hyperspy/pull/2729.

With the development version of hyperspy, one test which is still failing and this PR fixes it.

### Progress of the PR
- [x] fix `test_correct_grating_shift`,
- [x] fix wrong filename used in some tests, which was creating a file,
- [x] ready for review.



