### PR TITLE
force r to be int

### DIFF
--- a/lumispy/tests/utils/test_joinspectra.py
+++ b/lumispy/tests/utils/test_joinspectra.py
@@ -162,3 +162,5 @@ def test_joinspectra_FunctionalDA(average, scale, kind):
         assert s.data[-1] == 1
     else:
         assert s.data[-1] == 2
+    # test that join_spectra works for r that is float not int
+    s = join_spectra([s1, s2], r=2.1, average=average, scale=scale, kind=kind)

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -224,7 +224,8 @@ def join_spectra(S, r=50, scale=True, average=False, kind="slinear"):
         ):
             raise ValueError("Signal axes not overlapping")
     # Make sure that r is of type int
-    if not type(r) is int: r = int(r)
+    if not type(r) is int:
+        r = int(r)
 
     # take first spectrum as basis
     S1 = S[0].deepcopy()

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -223,6 +223,8 @@ def join_spectra(S, r=50, scale=True, average=False, kind="slinear"):
             < S[i].axes_manager.signal_axes[0].axis.min()
         ):
             raise ValueError("Signal axes not overlapping")
+    # Make sure that r is of type int
+    if not type(r) is int: r = int(r)
 
     # take first spectrum as basis
     S1 = S[0].deepcopy()


### PR DESCRIPTION
### Description of the change
Due to https://github.com/hyperspy/hyperspy/pull/2765, I realized that the overlap parameter `r` in `join_spectra` could be non integer, so forcing a conversion if it should be of a different type.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add tests,
- [x] ready for review.
