### PR TITLE
Fix installing test suite from source

### DIFF
--- a/lumispy/tests/signals/__init__.py
+++ b/lumispy/tests/signals/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.

--- a/lumispy/tests/utils/__init__.py
+++ b/lumispy/tests/utils/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2021 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
In https://github.com/hyperspy/hyperspy-extensions-list/runs/2815941965?check_suite_focus=true, only one test is run.

Relevant pytest documentation: https://docs.pytest.org/en/6.2.x/goodpractices.html#tests-as-part-of-application-code

### Progress of the PR
- [x] Add `__init__` file to install test files when installing from source.
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
pip install https://github.com/LumiSpy/lumispy/archive/refs/heads/master.zip
pytest --pyargs lumispy
```
Only one file of the test suite is included. 

```python
pip install https://github.com/ericpre/lumispy/archive/refs/heads/fix_test_discovery_dev.zip
pytest --pyargs lumispy
```
All the files of the test suite are included.
