### PR TITLE
Prepare for Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## 2021-11-23 - version 0.1.3
 ### Changed
 - Mentions of the now deleted `non_uniform_axes` branch in HyperSpy updated to `RELEASE_next_minor`
 - Change 'master' to 'main' branch
-- Updated/corrected badges in README.md
+- Updated/corrected badges and other things in README.md and other documentation files
 
 ## 2021-08-22 - version 0.1.2
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
 ## 2021-11-23 - version 0.1.3
 ### Changed
 - Mentions of the now deleted `non_uniform_axes` branch in HyperSpy updated to `RELEASE_next_minor`

--- a/lumispy/release_info.py
+++ b/lumispy/release_info.py
@@ -1,5 +1,5 @@
 name = "lumispy"
-version = "0.1.3"
+version = "0.2dev0"
 description = "Analysis of luminescence spectroscopy data with HyperSpy."
 author = "The LumiSpy developers"
 copyright = "Copyright 2019-2021, LumiSpy developers"

--- a/lumispy/release_info.py
+++ b/lumispy/release_info.py
@@ -1,5 +1,5 @@
 name = "lumispy"
-version = "0.2.dev0"
+version = "0.1.3"
 description = "Analysis of luminescence spectroscopy data with HyperSpy."
 author = "The LumiSpy developers"
 copyright = "Copyright 2019-2021, LumiSpy developers"

--- a/releasing_guide.md
+++ b/releasing_guide.md
@@ -3,7 +3,7 @@
 To publish a new LumiSpy release do the following steps:
 
 ### Preparation
-- Create a new PR to the 'main' branch for the release process
+- Create a new PR to the 'main' branch for the release process, e.g. `release_v0.1.1`
 - Make sure to have the code ready, including changelog
 - Set the correct version number in `lumispy/release_info.py` (increase the third 
   digit for a patch release, the second digit for a regular minor release, the

--- a/releasing_guide.md
+++ b/releasing_guide.md
@@ -10,6 +10,7 @@ To publish a new LumiSpy release do the following steps:
   first digit for a major release)
 - Let that PR collect comments for a day to ensure that other maintainers are comfortable 
   with releasing
+- Set correct date and version number in `CHANGELOG.md`
   
 ### Tag and Release
 - Create a tag e.g. `git tag -a v0.1.1 -m "LumiSpy version 0.1.1"`
@@ -22,7 +23,7 @@ To publish a new LumiSpy release do the following steps:
  ### Post-release action
 - Increment the version and set it back to dev: `vx.y.zdev`
 - Update version in other branches if necessary
-- Prepare `CHANGES.md` for development
+- Prepare `CHANGELOG.md` for development
 - Merge the PR
 
 ### Follow-up

--- a/releasing_guide.md
+++ b/releasing_guide.md
@@ -21,9 +21,9 @@ To publish a new LumiSpy release do the following steps:
   PyPi automatically). :warning: this is a point of no return :warning:
   
  ### Post-release action
-- Increment the version and set it back to dev: `vx.y.zdev`
+- Increment the version and set it back to dev: `vx.y.zdev0`
 - Update version in other branches if necessary
-- Prepare `CHANGELOG.md` for development
+- Prepare `CHANGELOG.md` for development by adding `## UNRELEASED` headline
 - Merge the PR
 
 ### Follow-up


### PR DESCRIPTION
Mainly documentation updates, see [CHANGELOG.md](https://github.com/LumiSpy/lumispy/blob/main/CHANGELOG.md). 

Released directly to avoid confusion with deleted `non_uniform_axis` in HyperSpy.