### PR TITLE
Make links work on PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ photoluminescence, electroluminescence, Raman, SNOM).
 If analysis using LumiSpy forms a part of published work, please consider 
 recognising the code development by citing the project using the [Zenodo-DOI](https://doi.org/10.5281/zenodo.4640445).
 
-Instructions on how to install LumiSpy and get started: [installation guide](INSTALLATION.md).
+Instructions on how to install LumiSpy and get started: [installation guide](https://github.com/LumiSpy/lumispy/blob/main/INSTALLATION.md).
 
 [Tutorials and example workflows](https://github.com/lumispy/lumispy-demos)
 have been curated as a series of Jupyter notebooks that you can work through 
 and modify to perform many common analyses. Simply:
 
 1. Download the `lumispy_demos` repository in your desired folder
-2. Load LumiSpy (see [installation guide](INSTALLATION.md))
+2. Load LumiSpy (see [installation guide](https://github.com/LumiSpy/lumispy/blob/main/INSTALLATION.md))
 3. In Jupyter lab, navigate to the folder and start using the notebook
 
 Everyone is welcome to contribute. Please read our
-[contributing guidelines](.github/CONTRIBUTING.md) and get started!
+[contributing guidelines](https://github.com/LumiSpy/lumispy/blob/main/.github/CONTRIBUTING.md) and get started!


### PR DESCRIPTION
Internal GitHub links do not work for `README.md` on PyPi (https://pypi.org/project/lumispy/), so replace by global links.