### PR TITLE
Fix map hyperspy RnM

### DIFF
--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -376,11 +376,11 @@ class LumiSpectrum(Signal1D, CommonLumi):
                 y = background.data
                 background = [x, y]
 
-            background_xy = np.array(background)
+            background_xy = np.asanyarray(background)
 
             if background_xy.shape[0] == 1 and background_xy.dtype != "O":
                 bkg_x = signal_x
-                bkg_y = background_xy
+                bkg_y = background_xy.squeeze()
             elif background_xy.shape[0] == 2 and background_xy.dtype != "O":
                 try:
                     bkg_x = background_xy[0]
@@ -395,7 +395,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
                     )
             else:
                 raise AttributeError(
-                    "Please, provide a background of shape (2, n) or (n)"
+                    "Please, provide a background of shape (2, n) or (n,)"
                 )
 
             if not np.array_equal(bkg_x, signal_x):
@@ -419,7 +419,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
     --------
     >>> import lumispy as lum
     >>> import numpy as np
-    
+
     # Spectrum:
     >>> S = lum.signals.LumiSpectrum(np.arange(5))
     >>> S.savetxt('spectrum.txt')
@@ -428,7 +428,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
     # 2.00000	2.00000
     # 3.00000	3.00000
     # 4.00000	4.00000
-    
+
     # Linescan:
     >>> L = lum.signals.LumiSpectrum(np.arange(25).reshape((5,5)))
     >>> L.savetxt('linescan.txt')
@@ -457,12 +457,12 @@ class LumiSpectrum(Signal1D, CommonLumi):
     --------
     The output of this function can be used to convert a signal object to a
     pandas dataframe, e.g. using `df = pd.Dataframe(S.to_array())`.
-    
+
     Examples
     --------
     >>> import lumispy as lum
     >>> import numpy as np
-    
+
     # Spectrum:
     >>> S = lum.signals.LumiSpectrum(np.arange(5))
     >>> S.to_array()
@@ -471,7 +471,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
     #    [2., 2.],
     #    [3., 3.],
     #    [4., 4.]])
-    
+
     # Linescan:
     >>> L = lum.signals.LumiSpectrum(np.arange(25).reshape((5,5)))
     >>> L.to_array()

--- a/lumispy/tests/signals/test_cl_spectrum.py
+++ b/lumispy/tests/signals/test_cl_spectrum.py
@@ -1,8 +1,8 @@
 from inspect import getfullargspec
-from unittest import TestCase
-from lumispy.signals.cl_spectrum import CLSpectrum
 import numpy as np
-from pytest import raises, skip
+import pytest
+
+from lumispy.signals.cl_spectrum import CLSpectrum
 
 
 param_list_signal_mask = [
@@ -18,14 +18,14 @@ param_list_signal_mask = [
 ]
 
 
-class TestCLSpectrum(TestCase):
+class TestCLSpectrum:
     def test__make_signal_mask(self):
         s = CLSpectrum(np.ones(10))
         s.axes_manager.signal_axes[0].scale = 100.5
         s.axes_manager.signal_axes[0].offset = 300
         for peak_list, mask_test in param_list_signal_mask:
             mask = s._make_signal_mask(peak_list)
-            assert np.allclose(mask, mask_test)
+            np.testing.assert_allclose(mask, mask_test)
 
     def test_remove_spikes(self):
         s = CLSpectrum(np.ones((2, 3, 30)))
@@ -39,16 +39,16 @@ class TestCLSpectrum(TestCase):
             try:
                 s.remove_spikes()
             except ImportError:
-                skip("HyperSpy version doesn't support spike removal.")
+                pytest.skip("HyperSpy version doesn't support spike removal.")
 
-        self.assertRaises(
-            AttributeError, s.remove_spikes, luminescence_roi=[1], signal_mask=[1]
-        )
+        with pytest.raises(AttributeError):
+            s.remove_spikes(luminescence_roi=[1], signal_mask=[1])
 
-        with self.assertWarns(UserWarning, msg="Threshold value found: 1.00"):
+        with pytest.warns(UserWarning, match="Threshold value: 1.00"):
             s1 = s.remove_spikes()
-            np.testing.assert_almost_equal(s1.data[1, 0, 1], 1, decimal=5)
-            np.testing.assert_almost_equal(s1.data[0, 2, 29], 1, decimal=5)
+
+        np.testing.assert_almost_equal(s1.data[1, 0, 1], 1, decimal=5)
+        np.testing.assert_almost_equal(s1.data[0, 2, 29], 1, decimal=5)
 
         lum_roi = [1, 1]
         s4 = s.remove_spikes(luminescence_roi=lum_roi, threshold=0.5)

--- a/lumispy/tests/signals/test_common_luminescence.py
+++ b/lumispy/tests/signals/test_common_luminescence.py
@@ -17,13 +17,12 @@
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy as np
-from unittest import TestCase
-from pytest import raises, warns
+import pytest
 
 from lumispy.signals import LumiSpectrum, LumiTransient
 
 
-class TestCommonLumi(TestCase):
+class TestCommonLumi:
     def test_crop_edges(self):
         s1 = LumiSpectrum(np.ones((10, 10, 10)))
         s2 = LumiTransient(np.ones((10, 10, 10, 10)))
@@ -34,7 +33,8 @@ class TestCommonLumi(TestCase):
         assert s1.axes_manager.navigation_shape[1] == 6
         assert s2.axes_manager.navigation_shape[0] == 6
         assert s2.axes_manager.navigation_shape[1] == 6
-        self.assertRaises(ValueError, s3.crop_edges, crop_px=2)
+        with pytest.raises(ValueError):
+            s3.crop_edges(crop_px=2)
 
     def test_remove_negative(self):
         s1 = LumiSpectrum(np.random.random((10, 10, 10))) - 0.3
@@ -87,18 +87,18 @@ class TestCommonLumi(TestCase):
         # Test for errors
         s4 = LumiSpectrum(np.ones((10)))
         s4.normalize(inplace=True)
-        with raises(AttributeError) as excinfo:
+        with pytest.raises(AttributeError) as excinfo:
             s4.scale_by_exposure(inplace=True, exposure=0.5)
         assert str(excinfo.value) == "Data was normalized and cannot be " "scaled."
         s5 = LumiSpectrum(np.ones((10)))
-        with raises(AttributeError) as excinfo:
+        with pytest.raises(AttributeError) as excinfo:
             s5.scale_by_exposure(inplace=True)
         assert (
             str(excinfo.value) == "Exposure not given and can not be "
             "extracted automatically from metadata."
         )
         s5.scale_by_exposure(inplace=True, exposure=0.5)
-        with raises(AttributeError) as excinfo:
+        with pytest.raises(AttributeError) as excinfo:
             s5.scale_by_exposure(inplace=True, exposure=0.5)
         assert str(excinfo.value) == "Data was already scaled."
 
@@ -143,7 +143,7 @@ class TestCommonLumi(TestCase):
         assert s3a == s3
         assert s4a == s4
         assert s4.metadata.Signal.quantity == "Normalized intensity"
-        with warns(UserWarning) as warninfo:
+        with pytest.warns(UserWarning) as warninfo:
             s1.normalize(inplace=True)
         assert len(warninfo) == 1
         assert warninfo[0].message.args[0][:8] == "Data was"

--- a/lumispy/tests/signals/test_luminescence_spectrum.py
+++ b/lumispy/tests/signals/test_luminescence_spectrum.py
@@ -16,10 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-from unittest import TestCase
 import numpy as np
+import pytest
+
 from lumispy.signals.luminescence_spectrum import LumiSpectrum
-from pytest import warns
 
 
 backgrounds = [
@@ -42,7 +42,7 @@ error_backgrounds = [
 ]
 
 
-class TestLumiSpectrum(TestCase):
+class TestLumiSpectrum:
     def test_remove_background_from_file(self):
         for bkg, output in backgrounds:
             s = LumiSpectrum(np.ones(50))
@@ -56,18 +56,18 @@ class TestLumiSpectrum(TestCase):
     def test_errors_raise(self):
         s = LumiSpectrum(np.ones(50))
         for bkg, error in error_backgrounds:
-            self.assertRaises(error, s.remove_background_from_file, bkg)
+            with pytest.raises(error):
+                s.remove_background_from_file(bkg)
         # Test that a GUI is opened if s.remove_background_from_file is passed without a background
         # s.remove_background_from_file()
         # Test double background removal
         s.remove_background_from_file(backgrounds[0][0], inplace=True)
-        self.assertRaises(
-            RecursionError, s.remove_background_from_file, backgrounds[0][0]
-        )
+        with pytest.raises(RecursionError):
+            s.remove_background_from_file(backgrounds[0][0])
 
-    # github-actions tests fail due to missing hyperspy-gui packages
-    # def test_warnings(self):
-    #    s = LumiSpectrum(np.ones(50))
-    #    with warns(SyntaxWarning) as warninfo:
-    #        s.remove_background_from_file(background=None, display=False)
-    #    assert warninfo[0].message.args[0][:18] == "Using the Hyperspy"
+    def test_warnings(self):
+        pytest.importorskip("hyperspy_gui_ipywidgets")
+        s = LumiSpectrum(np.ones(50))
+        with pytest.warns(SyntaxWarning) as warninfo:
+            s.remove_background_from_file(background=None, display=False)
+        assert warninfo[0].message.args[0][:18] == "Using the Hyperspy"

--- a/lumispy/tests/utils/test_axis-conversion.py
+++ b/lumispy/tests/utils/test_axis-conversion.py
@@ -15,17 +15,27 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
-from unittest import TestCase
 
+from inspect import getfullargspec
 from numpy import arange, ones
 from numpy.testing import assert_allclose
-from pytest import raises, mark, skip, warns
-from inspect import getfullargspec
+from pytest import raises, mark, skip
+import warnings
 
-from hyperspy.axes import *
+from hyperspy.axes import DataAxis
 
-from lumispy.signals import LumiSpectrum, CLSEMSpectrum
-from lumispy.utils.axes import *
+from lumispy.signals import LumiSpectrum
+from lumispy.utils.axes import (
+    nm2eV,
+    eV2nm,
+    axis2eV,
+    data2eV,
+    nm2invcm,
+    invcm2nm,
+    axis2invcm,
+    data2invcm,
+    solve_grating_equation,
+)
 
 
 def test_nm2eV():
@@ -323,6 +333,8 @@ def test_solve_grating_equation():
     if "scale" in getfullargspec(DataAxis)[0]:
         axis_class = DataAxis
     else:
+        from hyperspy.axes import UniformDataAxis
+
         axis_class = UniformDataAxis
 
     with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
### Description of the change
Fix for https://github.com/hyperspy/hyperspy/pull/2703.

The test `lumispy.tests.signals.test_luminescence_spectrum.TestLumiSpectrum` was failing with the following error:
```python
 self = <lumispy.tests.signals.test_luminescence_spectrum.TestLumiSpectrum testMethod=test_errors_raise>

    def test_errors_raise(self):
        s = LumiSpectrum(np.ones(50))
        for bkg, error in error_backgrounds:
            self.assertRaises(error, s.remove_background_from_file, bkg)
        # Test that a GUI is opened if s.remove_background_from_file is passed without a background
        # s.remove_background_from_file()
        # Test double background removal
        s.remove_background_from_file(backgrounds[0][0], inplace=True)
        self.assertRaises(
>           RecursionError, s.remove_background_from_file, backgrounds[0][0]
        )
E       AttributeError: 'LumiTransient' object has no attribute 'remove_background_from_file'
```
The issue was a `LumiSpectrum` (1D) was converted to `LumiTransient` signal (2D) because the `background` input has shape `(1, n)` and therefore the return signal had `(1, n)` as signal dimension instead of `(n, )`

### Progress of the PR
- [x] replace unittest with pytest,
- [n/a] update docstring (if appropriate),
- [n/a] add tests,
- [x] ready for review.


