### PR TITLE
Fix inconsistent docstring formatting

### DIFF
--- a/lumispy/signals/cl_spectrum.py
+++ b/lumispy/signals/cl_spectrum.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -**- coding: utf-8 -**-
 # Copyright 2019-2022 The LumiSpy developers
 #
 # This file is part of LumiSpy.
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Signal class for Cathodoluminescence spectral data.
+"""
+Signal class for cathodoluminescence spectral data
+--------------------------------------------------
 """
 
 from inspect import getfullargspec
@@ -30,7 +32,7 @@ from lumispy.signals import LumiSpectrum
 
 
 class CLSpectrum(LumiSpectrum):
-    """General 1D Cathodoluminescence signal class."""
+    """**General 1D cathodoluminescence signal class.**"""
 
     _signal_type = "CL"
     _signal_dimension = 1
@@ -147,6 +149,8 @@ class CLSpectrum(LumiSpectrum):
 
 
 class LazyCLSpectrum(LazySignal, CLSpectrum):
+    """**General lazy 1D cathodoluminescence signal class.**"""
+
     _lazy = True
 
     pass
@@ -157,6 +161,8 @@ class LazyCLSpectrum(LazySignal, CLSpectrum):
 
 
 class CLSEMSpectrum(CLSpectrum):
+    """**1D scanning electron microscopy cathodoluminescence signal class.**"""
+
     _signal_type = "CL_SEM"
 
     def correct_grating_shift(
@@ -207,6 +213,8 @@ class CLSEMSpectrum(CLSpectrum):
 
 
 class LazyCLSEMSpectrum(LazySignal, CLSEMSpectrum):
+    """**Lazy 1D scanning electron microscopy cathodoluminescence signal class.**"""
+
     _lazy = True
 
     pass
@@ -217,6 +225,7 @@ class LazyCLSEMSpectrum(LazySignal, CLSEMSpectrum):
 
 
 class CLSTEMSpectrum(CLSpectrum):
+    """**1D scanning transmission electron microscopy cathodoluminescence signal class.**"""
 
     _signal_type = "CL_STEM"
 
@@ -224,6 +233,7 @@ class CLSTEMSpectrum(CLSpectrum):
 
 
 class LazyCLSTEMSpectrum(LazySignal, CLSTEMSpectrum):
+    """**Lazy 1D scanning transmission electron microscopy cathodoluminescence signal class.**"""
 
     _lazy = True
 

--- a/lumispy/signals/cl_spectrum.py
+++ b/lumispy/signals/cl_spectrum.py
@@ -124,10 +124,12 @@ class CLSpectrum(LumiSpectrum):
         else:
             return signal
 
-    REMOVE_SPIKES_DOCSTRINGS = """
-        Hyperspy-based spike removal tool adapted to Lumispy to run non-interactively and
-        without noise addition by default.
+    REMOVE_SPIKES_DOCSTRINGS = """HyperSpy-based spike removal tool adapted to
+        LumiSpy to run non-interactively and without noise addition by default.
         %s
+        
+        Other Parameters
+        ----------------
         show_diagnosis_histogram: bool
             Plot or not the derivative histogram to show the magnitude of the spikes present.
         inplace: bool

--- a/lumispy/signals/cl_spectrum.py
+++ b/lumispy/signals/cl_spectrum.py
@@ -1,4 +1,4 @@
-# -**- coding: utf-8 -**-
+# -*- coding: utf-8 -*-
 # Copyright 2019-2022 The LumiSpy developers
 #
 # This file is part of LumiSpy.

--- a/lumispy/signals/cl_transient.py
+++ b/lumispy/signals/cl_transient.py
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Signal class for Luminescence transient data (2D).
+"""
+Signal class for cathodoluminescence transient data (2D)
+--------------------------------------------------------
 """
 
 from hyperspy.signals import Signal2D
@@ -26,7 +28,7 @@ from lumispy.signals.luminescence_transient import LumiTransient
 
 
 class CLTransient(LumiTransient):
-    """CL 2D luminescence signal class (transient/time resolved)."""
+    """**General 2D cathodoluminescence signal class (transient/time resolved)**"""
 
     _signal_type = "TRCL"
     _signal_dimension = 2
@@ -35,6 +37,8 @@ class CLTransient(LumiTransient):
 
 
 class LazyCLTransient(LazySignal, CLTransient):
+    """**General lazy 2D cathodoluminescence signal class (transient/time resolved)**"""
+
     _lazy = True
 
     pass

--- a/lumispy/signals/common_luminescence.py
+++ b/lumispy/signals/common_luminescence.py
@@ -158,7 +158,7 @@ class CommonLumi:
         pos : float, int
             If 'nan' (default), spectra are normalized to the maximum.
             If `float`, position along signal axis in calibrated units at which
-                to normalize the spectra.
+            to normalize the spectra.
             If `int`, index along signal axis at which to normalize the spectra.
         element_wise: boolean
             If `False` (default), a spectrum image is normalized by a common factor.

--- a/lumispy/signals/common_luminescence.py
+++ b/lumispy/signals/common_luminescence.py
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Signal class for Luminescence data (BaseSignal class).
+"""
+Signal class for luminescence data (BaseSignal class)
+-----------------------------------------------------
 """
 
 from numpy import isnan
@@ -24,7 +26,7 @@ from warnings import warn
 
 
 class CommonLumi:
-    """General Luminescence signal class (dimensionless)."""
+    """**General luminescence signal class (dimensionless)**"""
 
     def crop_edges(self, crop_px):
         """Crop the amount of pixels from the four edges of the scanning

--- a/lumispy/signals/el_spectrum.py
+++ b/lumispy/signals/el_spectrum.py
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Signal class for Electroluminescence spectral data.
+"""
+Signal class for electroluminescence spectral data
+--------------------------------------------------
 """
 
 from hyperspy._signals.lazy import LazySignal
@@ -25,9 +27,7 @@ from lumispy.signals import LumiSpectrum
 
 
 class ELSpectrum(LumiSpectrum):
-    """General 1D Electroluminescence signal class.
-    ----------
-    """
+    """**General 1D electroluminescence signal class**"""
 
     _signal_type = "EL"
     _signal_dimension = 1
@@ -36,6 +36,8 @@ class ELSpectrum(LumiSpectrum):
 
 
 class LazyELSpectrum(LazySignal, ELSpectrum):
+    """**General lazy 1D electroluminescence signal class**"""
+
     _lazy = True
 
     pass

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -19,9 +19,10 @@
 """Signal class for Luminescence spectral data (1D).
 """
 import warnings
+import numpy as np
 from inspect import getfullargspec
 from warnings import warn
-import numpy as np
+from textwrap import indent
 
 
 from hyperspy.signals import Signal1D
@@ -671,27 +672,27 @@ class LumiSpectrum(Signal1D, CommonLumi):
         inplace=False,
     ):
         """Converts signal axis of 1D signal (in pixels) to wavelength, solving
-    the grating equation. See `lumispy.axes.solve_grating_equation` for
-    more details.
+        the grating equation. See `lumispy.axes.solve_grating_equation` for
+        more details.
 
-    Parameters
-    ----------
-    %s
-    inplace : bool
-        If False, it returns a new object with the transformation. If True,
-        the original object is transformed, returning no object.
+        Parameters
+        ----------
+        %s
+            inplace : bool
+                If False, it returns a new object with the transformation. If
+                True, the original object is transformed, returning no object.
 
-    Returns
-    -------
-    signal : LumiSpectrum
-        A signal with calibrated wavelength units.
+        Returns
+        -------
+        signal : LumiSpectrum
+            A signal with calibrated wavelength units.
 
-    Examples
-    --------
-    >>> s = LumiSpectrum(np.ones(20),))
-    >>> s.px_to_nm_grating_solver(*params, inplace=True)
-    >>> s.axes_manager.signal_axes[0].units == 'nm'
-    """
+        Examples
+        --------
+        >>> s = LumiSpectrum(np.ones(20),))
+        >>> s.px_to_nm_grating_solver(*params, inplace=True)
+        >>> s.axes_manager.signal_axes[0].units == 'nm'
+        """
 
         nm_axis = solve_grating_equation(
             self.axes_manager.signal_axes[0],
@@ -714,7 +715,9 @@ class LumiSpectrum(Signal1D, CommonLumi):
 
         return s
 
-    px_to_nm_grating_solver.__doc__ %= GRATING_EQUATION_DOCSTRING_PARAMETERS
+    px_to_nm_grating_solver.__doc__ %= GRATING_EQUATION_DOCSTRING_PARAMETERS.replace(
+        "\n", "\n\t"
+    )
 
 
 class LazyLumiSpectrum(LazySignal, LumiSpectrum):

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -49,7 +49,7 @@ from lumispy.utils.io import (
 
 
 class LumiSpectrum(Signal1D, CommonLumi):
-    """General 1D Luminescence signal class."""
+    """**General 1D luminescence signal class.**"""
 
     _signal_type = "Luminescence"
     _signal_dimension = 1
@@ -128,8 +128,8 @@ class LumiSpectrum(Signal1D, CommonLumi):
         >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
         >>> S1.to_eV()
 
-        Note
-        ----
+        Notes
+        -----
         Using a non-linear axis works only for the RELEASE_next_minor development
         branch of HyperSpy.
         """
@@ -289,8 +289,8 @@ class LumiSpectrum(Signal1D, CommonLumi):
     >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
     >>> S1.to_invcm()
 
-    Note
-    ----
+    Notes
+    -----
     Using a non-linear axis works only for the RELEASE_next_minor development
     branch of HyperSpy.    
     """
@@ -433,8 +433,8 @@ class LumiSpectrum(Signal1D, CommonLumi):
     >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
     >>> S1.to_invcm(laser=325)
 
-    Note
-    ----
+    Notes
+    -----
     Using a non-linear axis works only for the RELEASE_next_minor development
     branch of HyperSpy.    
     """
@@ -517,8 +517,8 @@ class LumiSpectrum(Signal1D, CommonLumi):
         signal : LumiSpectrum
             A background subtracted signal.
 
-        Note
-        ----
+        Notes
+        -----
         This function does not work with non-linear axes.
         """
         if hasattr(self.metadata.Signal, "background_subtracted"):
@@ -619,8 +619,8 @@ class LumiSpectrum(Signal1D, CommonLumi):
     savetxt.__doc__ %= (SAVETXT_DOCSTRING, SAVETXT_PARAMETERS, SAVETXT_EXAMPLE)
 
     TOARRAY_EXAMPLE = """
-    Note
-    ----
+    Notes
+    -----
     The output of this function can be used to convert a signal object to a
     pandas dataframe, e.g. using `df = pd.Dataframe(S.to_array())`.
 
@@ -674,8 +674,8 @@ class LumiSpectrum(Signal1D, CommonLumi):
         the grating equation. See `lumispy.axes.solve_grating_equation` for
         more details.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         %s
         inplace : bool
             If False, it returns a new object with the transformation. If True,
@@ -718,6 +718,8 @@ class LumiSpectrum(Signal1D, CommonLumi):
 
 
 class LazyLumiSpectrum(LazySignal, LumiSpectrum):
+    """**General lazy 1D luminescence signal class.**"""
+
     _lazy = True
 
     pass

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -260,46 +260,45 @@ class LumiSpectrum(Signal1D, CommonLumi):
             return s2
 
     TO_INVCM_DOCSTRING = """
-    The intensity is converted from counts/nm (counts/µm) to counts/cm^-1
-    by doing a Jacobian transformation, see e.g. Wang and Townsend,
-    J. Lumin. 142, 202 (2013), doi:10.1016/j.jlumin.2013.03.052, which
-    ensures that integrated signals are correct also in the wavenumber 
-    domain. If the variance of the signal is known, i.e.
-    `metadata.Signal.Noise_properties.variance` is a signal representing the
-    variance, a squared renormalization of the variance is performed.
-    Note that if the variance is a number (not a signal instance), it is
-    converted to a signal if the Jacobian transformation is performed
+        The intensity is converted from counts/nm (counts/µm) to counts/cm^-1
+        by doing a Jacobian transformation, see e.g. Wang and Townsend,
+        J. Lumin. 142, 202 (2013), doi:10.1016/j.jlumin.2013.03.052, which
+        ensures that integrated signals are correct also in the wavenumber 
+        domain. If the variance of the signal is known, i.e.
+        `metadata.Signal.Noise_properties.variance` is a signal representing the
+        variance, a squared renormalization of the variance is performed.
+        Note that if the variance is a number (not a signal instance), it is
+        converted to a signal if the Jacobian transformation is performed
 
-    Parameters
-    ----------
-    inplace : boolean
-        If `False`, a new signal object is created and returned. Otherwise
-        (default) the operation is performed on the existing signal object.
-    jacobian : boolean
-        The default is to do the Jacobian transformation (recommended at
-        least for luminescence signals), but the transformation can be
-        suppressed by setting this option to `False`.
-    """
+        Parameters
+        ----------
+        inplace : boolean
+            If `False`, a new signal object is created and returned. Otherwise
+            (default) the operation is performed on the existing signal object.
+        jacobian : boolean
+            The default is to do the Jacobian transformation (recommended at
+            least for luminescence signals), but the transformation can be
+            suppressed by setting this option to `False`.
+        """
 
     TO_INVCM_EXAMPLE = """
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from lumispy import LumiSpectrum
-    >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
-    >>> S1.to_invcm()
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from lumispy import LumiSpectrum
+        >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
+        >>> S1.to_invcm()
 
-    Notes
-    -----
-    Using a non-linear axis works only for the RELEASE_next_minor development
-    branch of HyperSpy.    
-    """
+        Notes
+        -----
+        Using a non-linear axis works only for the RELEASE_next_minor development
+        branch of HyperSpy.    
+        """
 
     def to_invcm(self, inplace=True, jacobian=True):
         """Converts signal axis of 1D signal to non-linear wavenumber axis
         (cm^-1). Assumes wavelength in units of nm unless the axis units are
         specifically set to µm.
-
         %s
         %s
         """
@@ -426,17 +425,17 @@ class LumiSpectrum(Signal1D, CommonLumi):
     to_invcm.__doc__ %= (TO_INVCM_DOCSTRING, TO_INVCM_EXAMPLE)
 
     TO_INVCMREL_EXAMPLE = """
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from lumispy import LumiSpectrum
-    >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
-    >>> S1.to_invcm(laser=325)
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from lumispy import LumiSpectrum
+        >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
+        >>> S1.to_invcm(laser=325)
 
-    Notes
-    -----
-    Using a non-linear axis works only for the RELEASE_next_minor development
-    branch of HyperSpy.    
+        Notes
+        -----
+        Using a non-linear axis works only for the RELEASE_next_minor development
+        branch of HyperSpy.    
     """
 
     def to_invcm_relative(self, laser, inplace=True, jacobian=True):
@@ -504,10 +503,11 @@ class LumiSpectrum(Signal1D, CommonLumi):
         Parameters
         ----------
         background : array shape (2, n) or Signal1D
-            An array containing the background x-axis and the intensity values [[xs],[ys]] or a Signal1D object.
-            If the x-axis values do not match the signal_axes, then interpolation is done before subtraction.
-            If only the intensity values are provided, [ys], the functions assumes no interpolation needed.
-
+            An array containing the background x-axis and the intensity values
+            [[xs],[ys]] or a Signal1D object. If the x-axis values do not match
+            the signal_axes, then interpolation is done before subtraction. If
+            only the intensity values are provided, [ys], the functions assumes
+            no interpolation needed.
         inplace : boolean
             If False, it returns a new object with the transformation. If True,
             the original object is transformed, returning no object.
@@ -652,8 +652,8 @@ class LumiSpectrum(Signal1D, CommonLumi):
     def to_array(self, axes=True, transpose=False):
         """Returns luminescence spectrum object as numpy array (optionally
         including the axes).
-        %s
-        %s
+            %s
+            %s
         %s
         """
         return to_array(self, axes, transpose)
@@ -671,27 +671,27 @@ class LumiSpectrum(Signal1D, CommonLumi):
         inplace=False,
     ):
         """Converts signal axis of 1D signal (in pixels) to wavelength, solving
-        the grating equation. See `lumispy.axes.solve_grating_equation` for
-        more details.
+    the grating equation. See `lumispy.axes.solve_grating_equation` for
+    more details.
 
-        Parameters
-        ----------
-        %s
-        inplace : bool
-            If False, it returns a new object with the transformation. If True,
-            the original object is transformed, returning no object.
+    Parameters
+    ----------
+    %s
+    inplace : bool
+        If False, it returns a new object with the transformation. If True,
+        the original object is transformed, returning no object.
 
-        Returns
-        -------
-        signal : LumiSpectrum
-            A signal with calibrated wavelength units.
+    Returns
+    -------
+    signal : LumiSpectrum
+        A signal with calibrated wavelength units.
 
-        Examples
-        --------
-        >>> s = LumiSpectrum(np.ones(20),))
-        >>> s.px_to_nm_grating_solver(*params, inplace=True)
-        >>> s.axes_manager.signal_axes[0].units == 'nm'
-        """
+    Examples
+    --------
+    >>> s = LumiSpectrum(np.ones(20),))
+    >>> s.px_to_nm_grating_solver(*params, inplace=True)
+    >>> s.axes_manager.signal_axes[0].units == 'nm'
+    """
 
         nm_axis = solve_grating_equation(
             self.axes_manager.signal_axes[0],

--- a/lumispy/signals/luminescence_transient.py
+++ b/lumispy/signals/luminescence_transient.py
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Signal class for Luminescence transient data (2D).
+"""
+Signal class for luminescence transient data (2D)
+-------------------------------------------------
 """
 
 from hyperspy.signals import Signal2D
@@ -26,7 +28,7 @@ from lumispy.signals.common_luminescence import CommonLumi
 
 
 class LumiTransient(Signal2D, CommonLumi):
-    """General 2D luminescence signal class (transient/time resolved)."""
+    """**General 2D luminescence signal class (transient/time resolved)**"""
 
     _signal_type = "Luminescence"
     _signal_dimension = 2
@@ -35,6 +37,8 @@ class LumiTransient(Signal2D, CommonLumi):
 
 
 class LazyLumiTransient(LazySignal, LumiTransient):
+    """**General lazy 2D luminescence signal class (transient/time resolved)**"""
+
     _lazy = True
 
     pass

--- a/lumispy/signals/pl_spectrum.py
+++ b/lumispy/signals/pl_spectrum.py
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Signal class for Photoluminescence spectral data.
+"""
+Signal class for Photoluminescence spectral data
+------------------------------------------------
 """
 
 from hyperspy._signals.lazy import LazySignal
@@ -25,9 +27,7 @@ from lumispy.signals import LumiSpectrum
 
 
 class PLSpectrum(LumiSpectrum):
-    """General 1D Photoluminescence signal class.
-    ----------
-    """
+    """**General 1D photoluminescence signal class**"""
 
     _signal_type = "PL"
     _signal_dimension = 1
@@ -36,6 +36,7 @@ class PLSpectrum(LumiSpectrum):
 
 
 class LazyPLSpectrum(LazySignal, PLSpectrum):
+    """**General lazy 1D photoluminescence signal class**"""
 
     _lazy = True
 

--- a/lumispy/signals/pl_transient.py
+++ b/lumispy/signals/pl_transient.py
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Signal class for Luminescence transient data (2D).
+"""
+Signal class for photoluminescence transient data (2D)
+------------------------------------------------------
 """
 
 from hyperspy.signals import Signal2D
@@ -26,7 +28,7 @@ from lumispy.signals.luminescence_transient import LumiTransient
 
 
 class PLTransient(LumiTransient):
-    """PL 2D luminescence signal class (transient/time resolved)."""
+    """**General 2D photoluminescence signal class (transient/time resolved)**"""
 
     _signal_type = "TRPL"
     _signal_dimension = 2
@@ -35,6 +37,8 @@ class PLTransient(LumiTransient):
 
 
 class LazyPLTransient(LazySignal, PLTransient):
+    """**General lazy 2D photoluminescence signal class (transient/time resolved)**"""
+
     _lazy = True
 
     pass

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -393,7 +393,8 @@ def join_spectra(S, r=50, scale=True, average=False, kind="slinear"):
     return S1
 
 
-GRATING_EQUATION_DOCSTRING_PARAMETERS = r"""gamma_deg: float
+GRATING_EQUATION_DOCSTRING_PARAMETERS = r"""
+    gamma_deg: float
         Inclination angle between the focal plane and the centre of the grating
         (found experimentally from calibration). In degree.
     deviation_angle_deg: float
@@ -407,8 +408,7 @@ GRATING_EQUATION_DOCSTRING_PARAMETERS = r"""gamma_deg: float
     grating_central_wavelength_nm: float
         Wavelength at the centre of the grating, where exit slit is placed. In nm.
     grating_density_gr_mm: int
-        Grating density in gratings per mm.
-    """
+        Grating density in gratings per mm."""
 
 
 def solve_grating_equation(

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -393,10 +393,7 @@ def join_spectra(S, r=50, scale=True, average=False, kind="slinear"):
     return S1
 
 
-GRATING_EQUATION_DOCSTRING_PARAMETERS = r"""
-    Parameters
-    ----------
-    gamma_deg: float
+GRATING_EQUATION_DOCSTRING_PARAMETERS = r"""gamma_deg: float
         Inclination angle between the focal plane and the centre of the grating
         (found experimentally from calibration). In degree.
     deviation_angle_deg: float
@@ -411,7 +408,6 @@ GRATING_EQUATION_DOCSTRING_PARAMETERS = r"""
         Wavelength at the centre of the grating, where exit slit is placed. In nm.
     grating_density_gr_mm: int
         Grating density in gratings per mm.
-
     """
 
 

--- a/lumispy/utils/io.py
+++ b/lumispy/utils/io.py
@@ -92,8 +92,8 @@ TOARRAY_PARAMETERS = """
         `header`, `footer`, `comments`, or `encoding`."""
 
 TOARRAY_EXAMPLE = """
-    Note
-    --------
+    Notes
+    -----
     The output of this function can be used to convert a signal object to a
     pandas dataframe, e.g. using `df = pd.Dataframe(lum.to_array(S))`.
     

--- a/lumispy/utils/io.py
+++ b/lumispy/utils/io.py
@@ -73,7 +73,6 @@ SAVETXT_EXAMPLE = """
     """
 
 TOARRAY_DOCSTRING = """
-    
     Returns single spectra as two-column array.
     Returns linescan data as array with signal axis as first row and
     navigation axis as first column (flipped if `transpose=True`)."""
@@ -119,8 +118,7 @@ TOARRAY_EXAMPLE = """
           [ 1.,  5.,  6.,  7.,  8.,  9.],
           [ 2., 10., 11., 12., 13., 14.],
           [ 3., 15., 16., 17., 18., 19.],
-          [ 4., 20., 21., 22., 23., 24.]])
-    """
+          [ 4., 20., 21., 22., 23., 24.]])"""
 
 
 def to_array(S, axes=True, transpose=False):


### PR DESCRIPTION
* [x] headline for each signal class file
* [x] set signal class docstrings bold
* [x] Correct inconsistent naming of docstring sections (Parameters, Notes)
* [x] Correct inconsistent lengths of section markers
* [x] fix error in docstring formatting mentioned in #105, (closes #105)

