### PR TITLE
Metadata structure

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -52,6 +52,7 @@ Contents
    user_guide/introduction.rst
    user_guide/signal_axis.rst
    user_guide/fitting_luminescence.rst
+   user_guide/metadata_structure.rst
 
 .. toctree::
    :maxdepth: 2

--- a/doc/source/user_guide/introduction.rst
+++ b/doc/source/user_guide/introduction.rst
@@ -16,7 +16,7 @@ measurements, such as absorption or transmission spectroscopy, scanning optical
 near field miscroscopy (SNOM), as well as fourier-transform infrared
 spectroscopy (FTIR).
 
-**LumiSpy** is an extension to the python package `HyperSpy <https://hyperspy.org>`_
+**LumiSpy** is an extension to the python package **`HyperSpy <https://hyperspy.org>`_**
 that facilitates hyperspectral data analysis, i.e. maps or linescans where a
 spectrum is collected at each pixel. Or more general, multidimensional datasets
 that can be described as multidimensional arrays of a given signal. Notable 
@@ -69,8 +69,8 @@ As an extension to HyperSpy, LumiSpy provides several signal types extending the
 the LumiSpy library is installed, these additional signal types are directly
 available to HyperSpy. To print all available specialised
 :external:py:class:`hyperspy.signal.BaseSignal` subclasses installed in your
- ystem call the :external:py:func:`hyperspy.utils.print_known_signal_types`
- function:
+system call the :external:py:func:`hyperspy.utils.print_known_signal_types`
+function:
 
 .. code-block:: python
 

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -59,7 +59,7 @@ while parallel acquisition with a CCD is characterized by the
         │   ├── signal_amplification (xN)
         │   ├── readout_rate (MHz)
         │   └── pixel_width (mm)
-        └── SpectralImage
+        └── Spectral_image
             ├── mode
             ├── step_size
             ├── step_size_units (nm)
@@ -236,7 +236,7 @@ pixel_width
     Diameter of a pixel in mm.
 
 
-SpectralImage
+Spectral_image
 =============
 
 Contains information about mapping parameters, such as step size, drift

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -16,6 +16,14 @@ the ones for leaves are not capitalized. When a leaf contains a quantity that
 is not dimensionless, the units can be given in an extra leaf with the same
 label followed by the ``_units`` suffix.
 
+Besides directly accesing the metadata tree structure, e.g.
+``s.metadata.Signal.signal_type``, the HyperSpy methods
+:external:py:meth:`hyperspy.misc.utils.DictionaryTreeBrowser.set_item`,
+:external:py:meth:`hyperspy.misc.utils.DictionaryTreeBrowser.has_item` and
+:external:py:meth:`hyperspy.misc.utils.DictionaryTreeBrowser.get_item`
+can be used to add to, search for and read from items in the metadata tree,
+respectively.
+
 The luminescence specific metadata structure is represented in the following
 tree diagram. The default units are given in parentheses. Details about the
 leaves can be found in the following sections of this chapter. Note that not
@@ -26,6 +34,7 @@ while parallel acquisition with a CCD is characterized by the
 
 ::
 
+    metadata
     ├── General
     │   └── # see HyperSpy
     ├── Sample

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -18,7 +18,7 @@ label followed by the ``_units`` suffix.
 The luminescence specific metadata structure is represented in the following
 tree diagram. The default units are given in parentheses. Details about the
 leaves can be found in the following sections of this chapter. Note that not
-all types of leaves will apply to every type of measurements. For example,
+all types of leaves will apply to every type of measurement. For example,
 while parallel acquisition with a CCD is characterized by the
 ``central_wavelength``, a serial acquisition with a PMT will require a
 ``start_wavelength`` and a ``step_size``.
@@ -26,8 +26,19 @@ while parallel acquisition with a CCD is characterized by the
 ::
 
     └── Acquisition_instrument
+        ├── General
+        │   └── see HyperSpy
+        ├── Sample
+        │   └── see HyperSpy
+        ├── Laser / SEM / TEM
+        │   ├── laser_type
+        │   ├── model
+        │   ├── wavelength (nm)
+        │   ├── power (mW)
+        │   ├── objective_magnification
+        │   └── for SEM/TEM see HyperSpy
         ├── Spectrometer
-        │   ├── model_name
+        │   ├── model
         │   ├── acquisition_mode
         │   ├── entrance_slit_width (mm)
         │   ├── exit_slit_width (mm)
@@ -46,7 +57,7 @@ while parallel acquisition with a CCD is characterized by the
         │       └── cut_off_wavelength (nm)
         ├── Detector
         │   ├── detector_type
-        │   ├── model_name
+        │   ├── model
         │   ├── frames
         │   ├── integration_time (s)
         │   ├── saturation_fraction
@@ -61,9 +72,56 @@ while parallel acquisition with a CCD is characterized by the
             ├── drift_correction_periodicity
             └── drift_correction_units (s)
 
-    
-::
 
+General
+=======
+
+See `HyperSpy-Metadata-General
+<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#general>`_.
+
+Sample
+======
+
+See `HyperSpy-Metadata-Sample
+<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#sample>`_.
+
+Laser / SEM / TEM
+=================
+
+For **SEM** or **TEM** see `HyperSpy-Metadata-SEM
+<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#sem>`_
+or `HyperSpy-Metadata-TEM
+<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#tem>`_.
+
+
+Laser
+-----
+
+laser_type
+    type: string
+
+    The type of laser used, e.g. 'HeCd'.
+
+model
+    type: string
+
+    Model of the laser (branding by manufacturer).
+
+wavelength
+    type: float
+
+    Emission wavelength of the exciting laser in nm.
+
+power
+    type: float
+
+    Measured power of the excitation laser in mW.
+
+objective_magnification
+    type: int
+
+    Magnification of the microscope objective used to focus the beam to the
+    sample.
 
 Spectrometer
 ============
@@ -72,10 +130,10 @@ Contains information about the spectrometer, configuration and grating used
 for the measurement. In case multiple spectrometers are connected in series,
 they should be numbered `Spectrometer_1`, etc.
 
-model_name
+model
     type: string
 
-    Model of the spectrometer.
+    Model of the spectrometer (branding by manufacturer).
 
 acquisition_mode
     type: string
@@ -170,9 +228,9 @@ detector_type
     type: string
 
     The type of detector used to acquire the signal (CCD, PMT, StreakCamera, 
-    TCSPD)
+    TCSPD).
 
-model_name
+model
     type: string
 
     The model of the used detector.

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -27,13 +27,13 @@ while parallel acquisition with a CCD is characterized by the
 ::
 
     ├── General
-    │   └── see HyperSpy
+    │   └── # see HyperSpy
     ├── Sample
-    │   └── see HyperSpy
+    │   └── # see HyperSpy
     ├── Signal
     │   ├── signal_type
     │   ├── quantity
-    │   └── otherwise see HyperSpy
+    │   └── # otherwise see HyperSpy
     └── Acquisition_instrument
         ├── Laser / SEM / TEM
         │   ├── laser_type
@@ -41,7 +41,13 @@ while parallel acquisition with a CCD is characterized by the
         │   ├── wavelength (nm)
         │   ├── power (mW)
         │   ├── objective_magnification
-        │   └── for SEM/TEM see HyperSpy
+        │   └── Filter
+        │   │   ├── filter_type
+        │   │   ├── position
+        │   │   ├── optical_density
+        │   │   ├── cut_on_wavelength (nm)
+        │   │   └── cut_off_wavelength (nm)
+        │   └── # for SEM/TEM see HyperSpy
         ├── Spectrometer
         │   ├── model
         │   ├── acquisition_mode
@@ -150,6 +156,42 @@ objective_magnification
     Magnification of the microscope objective used to focus the beam to the
     sample.
 
+.. _filter_label:
+
+Filter
+-------
+
+Information about additional filters entered into the lightpath before the
+sample. In case multiple filters are used, they should be numbered
+`Filter_1`, etc.
+
+filter_type
+    type: string
+
+    Type of filter (e.g. 'optical density', 'short pass', 'long pass',
+    'bandpass', 'color').
+
+position
+    type: string
+
+    Position in the beam (e.g. 'excitation' vs. 'detection' in case of optical
+    excitation).
+
+optical_density
+    type: float
+
+    Optical density in case of an intensity filter.
+
+cut_on_wavelength
+    type: float
+
+    Cut on wavelength in nm in case of a long-pass or bandpass filter.
+
+cut_off_wavelength
+    type: float
+
+    Cut off wavelength in nm in case of a short-pass or bandpass filter.
+
 Spectrometer
 ============
 
@@ -215,35 +257,10 @@ blazing_wavelength
 Filter
 -------
 
-Information about additional filters entered into the lightpath. In case
-multiple filters are used, they should be numbered `Filter_1`, etc.
-
-filter_type
-    type: string
-
-    Type of filter (e.g. 'optical density', 'short pass', 'long pass',
-    'bandpass', 'color').
-
-position
-    type: string
-
-    Position in the beam (e.g. 'excitation' vs. 'detection' in case of optical
-    excitation).
-
-optical_density
-    type: float
-
-    Optical density in case of an intensity filter.
-
-cut_on_wavelength
-    type: float
-
-    Cut on wavelength in nm in case of a long-pass or bandpass filter.
-
-cut_off_wavelength
-    type: float
-
-    Cut off wavelength in nm in case of a short-pass or bandpass filter.
+Information about additional filters entered into the lightpath after the
+sample. In case multiple filters are used, they should be numbered
+`Filter_1`, etc. See :ref:`filter-label` above for details on items that
+may potentially be included.
 
 Detector
 ========

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -50,7 +50,7 @@ while parallel acquisition with a CCD is characterized by the
         │   ├── wavelength (nm)
         │   ├── power (mW)
         │   ├── objective_magnification
-        │   └── Filter
+        │   ├── Filter
         │   │   ├── filter_type
         │   │   ├── position
         │   │   ├── optical_density

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -1,0 +1,259 @@
+.. _metadata_structure:
+
+LumiSpy metadata structure
+**************************
+
+LumiSpy extends the `HyperSpy metadata structure <https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_ with conventions for metadata specific to its signal types. Refer to `HyperSpy <https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_ for general metadata fields.
+
+The metadata of any **signal objects** is stored in the `metadata` attribute, which has a tree structure.
+
+By convention, the node labels are capitalized and the ones for leaves are not capitalized.
+
+When a leaf contains a quantity that is not dimensionless, the units can be given in an extra leaf with the same label followed by the `_units` suffix.
+
+The luminescence specific metadata structure is represented in the following tree diagram. The
+default units are given in parentheses. Details about the leaves can be found
+in the following sections of this chapter. Note that not all types of leaves will apply to every type of measurements. For example, while parallel acquisition with a CCD is characterized by the `central_wavelength`, a serial acquisition with a PMT will require a `start_wavelength` and a `step_size`.
+
+::
+
+    └── Acquisition_instrument
+        ├── Spectrometer
+        │   ├── model_name
+        │   ├── acquisition_mode
+        │   ├── entrance_slit_width (mm)
+        │   ├── central_wavelength (nm)
+        │   ├── start_wavelength (nm)
+        │   ├── step_size (nm)
+        │   ├── Grating
+        │   │   ├── groove_density (grooves/mm)
+        │   │   ├── blazing_angle (º)
+        │   │   └── blazing_wavelength (nm)
+        │   └── Filters
+        │       └── Filter1
+        │           ├── filter_type
+        │           ├── position
+        │           ├── optical_density
+        │           ├── cut_on_wavelength (nm)
+        │           └── cut_off_wavelength (nm)
+        ├── Detector
+        |   ├── detector_type
+        │   ├── model_name
+        │   ├── life_time (ms)
+        │   ├── real_time (ms)
+        │   ├── exposure (s)
+        │   ├── frame_number = 1
+        │   ├── integration_time (s)
+        │   ├── saturation_fraction
+        │   ├── binning
+        │   ├── processing
+        │   ├── read_area
+        │   ├── signal_amplification (xN)
+        │   ├── readout_rate (MHz)
+        │   └── pixel_width (mm)
+        └── SpectralImage
+            ├── mode
+            ├── step_size
+            ├── step_size_units (nm)
+            ├── drift_correction_periodicity
+            └── drift_correction_units (s)
+
+    
+::
+
+
+Spectrometer
+============
+
+Contains information about the spectrometer, configuration and grating used
+for the measurement.
+
+model_name
+    type: string
+
+    Model of the spectrometer.
+
+acquisition_mode
+    type: string
+
+    Acquisition mode (e.g. 'Parallel dispersive', versus 'Serial dispersive').
+
+entrance_slit_width
+    type: float
+
+    Width of the entrance slit in mm.
+
+exit_slit_width
+    type: float
+
+    Width of the exit slit (serial acquisition) in mm.
+
+central_wavelength
+    type: float
+
+    Central wavelength during acquisition (parallel acquisition).
+    
+start_wavelength
+    type: float
+
+    Start wavelength in nm (serial acquisition).
+
+step_size
+    type: float
+
+    Step size in nm (serial acquisition).
+
+Grating
+-------
+
+Information of the dispersion grating employed in the measurement.
+
+groove_density
+    type: int
+
+    Density of lines on the grating in grooves/mm.
+
+blazing_angle
+    type: int
+
+    Angle in degree (º) that the grating is blazed at.
+
+blazing_wavelength
+    type: int
+
+    Wavelength that the grating blaze is optimized for in 'nm'.
+
+Filters
+-------
+
+Information about additional filters entered into the lightpath.
+
+Filter1
+^^^^^^^
+
+Multiple filters are numbered sequentially.
+
+filter_type
+    type: string
+
+    Type of filter (e.g. 'optical density', 'short pass', 'long pass',
+    'bandpass', 'color').
+
+position
+    type: string
+
+    Position in the beam (e.g. 'excitation' vs. 'detection' in case of optical
+    excitation).
+
+optical_density
+    type: float
+
+    Optical density in case of an intensity filter.
+
+cut_on_wavelength (nm)
+    type: int
+
+    Cut on wavelength in nm in case of a long-pass or bandpass filter.
+
+cut_off_wavelength (nm)
+    type: int
+
+    Cut off wavelength in nm in case of a short-pass or bandpass filter.
+
+Detector
+========
+
+Contains information about the detector used to acquire the signal. Contained
+leaves will differ depending on the type of detector.
+
+detector_type
+    type: string
+
+    The type of detector used to acquire the signal (CCD, PMT, StreakCamera, 
+    TCSPD)
+
+model_name
+    type: string
+
+    The model of the used detector.
+
+life_time (ms)
+    type: float
+
+real_time (ms)
+
+exposure (s)
+
+
+frame_number
+
+
+integration_time (s)
+
+
+saturation_fraction
+    type: float
+
+binning
+    type: tuple of int
+
+    A tuple that describes the binning of a parallel detector such a CCD on
+    readout in x and y directions.
+
+processing
+    type: string
+
+    Information about automatic processing performed on the data, e.g. 'dark
+    subtracted'.
+
+read_area
+    type: tuple of int
+
+    Tuple that specifies range of pixels on a detector that are read out.
+
+signal_amplification
+    type: float
+
+     (xN)
+
+readout_rate
+    type: float
+
+     (MHz)
+
+pixel_width
+    type: float
+
+    Diameter of a pixel in mm.
+
+
+SpectralImage
+=============
+
+Contains information about mapping parameters, such as step size, drift
+correction, etc.
+
+mode
+    type: string
+
+    Mode of the spectrum image acquisition such as 'Map' or 'Linescan'.
+
+step_size
+    type: float
+
+    Distance between subsequent pixels in the spectral image.
+
+step_size_units
+    type: string
+
+    Units of the step size (standard 'nm').
+
+drift_correction_periodicity
+    type: int/float
+
+    Periodicity of the drift correction in specified units (standard s).
+
+drift_correction_units
+    type: string
+
+    Units of the drift correction such as 's', 'px', 'rows'.

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -5,7 +5,8 @@ LumiSpy metadata structure
 
 LumiSpy extends the `HyperSpy metadata structure
 <https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_
-with conventions for metadata specific to its signal types. Refer to `HyperSpy
+with conventions for metadata specific to its signal types. Refer to the
+`HyperSpy metadata documentation
 <https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_
 for general metadata fields.
 

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -26,11 +26,15 @@ while parallel acquisition with a CCD is characterized by the
 
 ::
 
+    ├── General
+    │   └── see HyperSpy
+    ├── Sample
+    │   └── see HyperSpy
+    ├── Signal
+    │   ├── signal_type
+    │   ├── quantity
+    │   └── otherwise see HyperSpy
     └── Acquisition_instrument
-        ├── General
-        │   └── see HyperSpy
-        ├── Sample
-        │   └── see HyperSpy
         ├── Laser / SEM / TEM
         │   ├── laser_type
         │   ├── model
@@ -85,6 +89,28 @@ Sample
 
 See `HyperSpy-Metadata-Sample
 <https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#sample>`_.
+
+Signal
+======
+
+signal_type
+    type: string
+
+    String that describes the type of signal. The LumiSpy specific signal classes are
+    summarized under :ref:`signal_types`.
+
+quantity
+    type: string
+
+    The name of the quantity of the “intensity axis” with the units in round brackets if
+    required, for example 'Intensity (counts/s)'.
+
+See `HyperSpy-Metadata-Signal
+<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#sample>`_
+for additional fields.
+
+Acquisition Instrument
+======================
 
 Laser / SEM / TEM
 =================

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -30,6 +30,7 @@ while parallel acquisition with a CCD is characterized by the
         │   ├── model_name
         │   ├── acquisition_mode
         │   ├── entrance_slit_width (mm)
+        │   ├── exit_slit_width (mm)
         │   ├── central_wavelength (nm)
         │   ├── start_wavelength (nm)
         │   ├── step_size (nm)
@@ -37,28 +38,22 @@ while parallel acquisition with a CCD is characterized by the
         │   │   ├── groove_density (grooves/mm)
         │   │   ├── blazing_angle (º)
         │   │   └── blazing_wavelength (nm)
-        │   └── Filters
-        │       └── Filter1
-        │           ├── filter_type
-        │           ├── position
-        │           ├── optical_density
-        │           ├── cut_on_wavelength (nm)
-        │           └── cut_off_wavelength (nm)
+        │   └── Filter
+        │       ├── filter_type
+        │       ├── position
+        │       ├── optical_density
+        │       ├── cut_on_wavelength (nm)
+        │       └── cut_off_wavelength (nm)
         ├── Detector
-        |   ├── detector_type
+        │   ├── detector_type
         │   ├── model_name
-        │   ├── life_time (ms)
-        │   ├── real_time (ms)
-        │   ├── exposure (s)
-        │   ├── frame_number = 1
+        │   ├── frame_number
         │   ├── integration_time (s)
         │   ├── saturation_fraction
         │   ├── binning
         │   ├── processing
-        │   ├── read_area
-        │   ├── signal_amplification (xN)
-        │   ├── readout_rate (MHz)
-        │   └── pixel_width (mm)
+        │   ├── sensor_roi
+        │   └── pixel_width (µm)
         └── Spectral_image
             ├── mode
             ├── step_size
@@ -74,7 +69,8 @@ Spectrometer
 ============
 
 Contains information about the spectrometer, configuration and grating used
-for the measurement.
+for the measurement. In case multiple spectrometers are connected in series,
+they should be numbered `Spectrometer_1`, etc.
 
 model_name
     type: string
@@ -131,15 +127,11 @@ blazing_wavelength
 
     Wavelength that the grating blaze is optimized for in nm.
 
-Filters
+Filter
 -------
 
-Information about additional filters entered into the lightpath.
-
-Filter1
-^^^^^^^
-
-Multiple filters are numbered sequentially.
+Information about additional filters entered into the lightpath. In case
+multiple filters are used, they should be numbered `Filter_1`, etc.
 
 filter_type
     type: string
@@ -185,23 +177,23 @@ model_name
 
     The model of the used detector.
 
-life_time (ms)
-    type: float
-
-real_time (ms)
-    type: float
-
-exposure (s)
-    type: float
-
 frame_number
     type: int
+
+    Number of frames that are summed to yield the total integration time.
 
 integration_time (s)
     type: float
 
+    Time over which the signal is integrated. In case multiple frames are
+    summed, it is the total exposure time. In case of serial acquisition, it is
+    the dwell time per data point.
+
 saturation_fraction
     type: float
+
+    Fraction of the signal intensity compared with the saturation threshold of
+    the CCD.
 
 binning
     type: tuple of int
@@ -215,29 +207,19 @@ processing
     Information about automatic processing performed on the data, e.g. 'dark
     subtracted'.
 
-read_area
+sensor_roi
     type: tuple of int
 
     Tuple that specifies range of pixels on a detector that are read out.
 
-signal_amplification
-    type: float
-
-     in xN
-
-readout_rate
-    type: float
-
-     in MHz
-
 pixel_width
     type: float
 
-    Diameter of a pixel in mm.
+    Diameter of a pixel in µm.
 
 
 Spectral_image
-=============
+==============
 
 Contains information about mapping parameters, such as step size, drift
 correction, etc.

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -47,7 +47,7 @@ while parallel acquisition with a CCD is characterized by the
         ├── Detector
         │   ├── detector_type
         │   ├── model_name
-        │   ├── frame_number
+        │   ├── frames
         │   ├── integration_time (s)
         │   ├── saturation_fraction
         │   ├── binning
@@ -151,12 +151,12 @@ optical_density
     Optical density in case of an intensity filter.
 
 cut_on_wavelength
-    type: int
+    type: float
 
     Cut on wavelength in nm in case of a long-pass or bandpass filter.
 
 cut_off_wavelength
-    type: int
+    type: float
 
     Cut off wavelength in nm in case of a short-pass or bandpass filter.
 
@@ -177,7 +177,7 @@ model_name
 
     The model of the used detector.
 
-frame_number
+frames
     type: int
 
     Number of frames that are summed to yield the total integration time.

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -84,11 +84,9 @@ while parallel acquisition with a CCD is characterized by the
         │   ├── binning
         │   ├── processing
         │   ├── sensor_roi
-        │   └── pixel_width (µm)
+        │   └── pixel_size (µm)
         └── Spectral_image
             ├── mode
-            ├── step_size
-            ├── step_size_units (nm)
             ├── drift_correction_periodicity
             └── drift_correction_units (s)
 
@@ -159,7 +157,7 @@ power
 
     Measured power of the excitation laser in mW.
 
-objective_magnification
+magnification
     type: int
 
     Magnification of the microscope objective used to focus the beam to the
@@ -321,12 +319,15 @@ processing
 sensor_roi
     type: tuple of int
 
-    Tuple that specifies range of pixels on a detector that are read out.
+    Tuple of length 2 or 4 that specifies range of pixels on a detector that
+    are read out: (offset x, offset y, size x, size y) for a 2D array detector
+    and (offset, size) for a 1D line detector.
 
-pixel_width
-    type: float
+pixel_size
+    type: float or tuple of float
 
-    Diameter of a pixel in µm.
+    Size of a pixel in µm. Tuple of length 2 (width, height), when the pixel is
+    not square.
 
 
 Spectral_image
@@ -339,16 +340,6 @@ mode
     type: string
 
     Mode of the spectrum image acquisition such as 'Map' or 'Linescan'.
-
-step_size
-    type: float
-
-    Distance between subsequent pixels in the spectral image.
-
-step_size_units
-    type: string
-
-    Units of the step size (standard 'nm').
 
 drift_correction_periodicity
     type: int/float

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -3,17 +3,25 @@
 LumiSpy metadata structure
 **************************
 
-LumiSpy extends the `HyperSpy metadata structure <https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_ with conventions for metadata specific to its signal types. Refer to `HyperSpy <https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_ for general metadata fields.
+LumiSpy extends the `HyperSpy metadata structure
+<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_
+with conventions for metadata specific to its signal types. Refer to `HyperSpy
+<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_
+for general metadata fields.
 
-The metadata of any **signal objects** is stored in the `metadata` attribute, which has a tree structure.
+The metadata of any **signal objects** is stored in the `metadata` attribute,
+which has a tree structure. By convention, the node labels are capitalized and
+the ones for leaves are not capitalized. When a leaf contains a quantity that
+is not dimensionless, the units can be given in an extra leaf with the same
+label followed by the ``_units`` suffix.
 
-By convention, the node labels are capitalized and the ones for leaves are not capitalized.
-
-When a leaf contains a quantity that is not dimensionless, the units can be given in an extra leaf with the same label followed by the `_units` suffix.
-
-The luminescence specific metadata structure is represented in the following tree diagram. The
-default units are given in parentheses. Details about the leaves can be found
-in the following sections of this chapter. Note that not all types of leaves will apply to every type of measurements. For example, while parallel acquisition with a CCD is characterized by the `central_wavelength`, a serial acquisition with a PMT will require a `start_wavelength` and a `step_size`.
+The luminescence specific metadata structure is represented in the following
+tree diagram. The default units are given in parentheses. Details about the
+leaves can be found in the following sections of this chapter. Note that not
+all types of leaves will apply to every type of measurements. For example,
+while parallel acquisition with a CCD is characterized by the
+``central_wavelength``, a serial acquisition with a PMT will require a
+``start_wavelength`` and a ``step_size``.
 
 ::
 
@@ -121,7 +129,7 @@ blazing_angle
 blazing_wavelength
     type: int
 
-    Wavelength that the grating blaze is optimized for in 'nm'.
+    Wavelength that the grating blaze is optimized for in nm.
 
 Filters
 -------
@@ -150,12 +158,12 @@ optical_density
 
     Optical density in case of an intensity filter.
 
-cut_on_wavelength (nm)
+cut_on_wavelength
     type: int
 
     Cut on wavelength in nm in case of a long-pass or bandpass filter.
 
-cut_off_wavelength (nm)
+cut_off_wavelength
     type: int
 
     Cut off wavelength in nm in case of a short-pass or bandpass filter.
@@ -181,15 +189,16 @@ life_time (ms)
     type: float
 
 real_time (ms)
+    type: float
 
 exposure (s)
-
+    type: float
 
 frame_number
-
+    type: int
 
 integration_time (s)
-
+    type: float
 
 saturation_fraction
     type: float
@@ -214,12 +223,12 @@ read_area
 signal_amplification
     type: float
 
-     (xN)
+     in xN
 
 readout_rate
     type: float
 
-     (MHz)
+     in MHz
 
 pixel_width
     type: float


### PR DESCRIPTION
Introduce LumiSpy specific conventions on metadata structure as brought up in #53.

Decisions I have taken for the moment:
- 'Spectrometer', 'Detector', and 'Spectral_image' are independent nodes on the 'Acquisition_instrument' level. None of them is really hierarchically below any of the others.
- 'Detector' is the general node and contains the 'detector_type'. This way, general parameters such as the 'exposure_time' are not hidden in a detector-specific subnode.
- Besides 'Grating', the 'Spectrometer' contains an additional subnode 'Filters'.

Open questions:
- Should we have separate 'entrance_slit_width' and 'exit_slit_width' parameters? In serial acquisition both can play a role and (though uncommon) may theoretically be set independently. Alternative would be have a general 'slit_width' leaf.
- The biggest issue is the different conventions on the integration time. Both CL and PL systems I work with allow for multiple 'frames' with a certain 'dwell_time' that add up to an overall 'integration_time'. The attolight system has a more specific distinction between 'real_time' and 'life_time'. How does that fit in, which one should be the integration_time? We should have one commonly defined parameter complemented by additional ones.
- Overall, this is just a convention on the structure and proposal for major leafs that can be contained. Everyone is free to add additional information or leave out some. As such the structure is somewhat exemplary - so we could out leave more specific leaves like 'saturation_fraction', 'signal_amplification', 'readout_rate' from the documentation.
- Where would we put the measurement temperature?

Broader questions:
- Similar to detector, a 'Excitation_source' could make sense. Alternatively, the 'SEM/TEM' nodes of HyperSpy could be complemented by a 'Laser' node.