### PR TITLE
Update metadata used in scale_by_exposure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,12 +11,14 @@ UNRELEASED
 Added
 -----
 - Set up read the docs documentation
+- Added metadata convention
 - Add proper handling of variance on Jacobian transformation during axis conversion (eV, invcm)
 
 Changed
 -------
 - Fix error in background dimensions that allows compatibility for updated `map` in HyperSpy (failing integration tests)
 - Fix for links in PyPi
+- Deprecate `exposure` argument of `scale_by_exposure` in favor of `integration_time` in line with metadata convention
 
 2021-11-23 - version 0.1.3
 ==========================

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,7 +21,10 @@ Pull Requests
 =============
 
 If you want to contribute to the LumiSpy source code, you can send us a
-`pull request <https://github.com/lumispy/lumispy/pulls>`_.
+`pull request <https://github.com/lumispy/lumispy/pulls>`_. Small bug fixes are
+corrections to the user guide are typically a good starting point. But don't
+hesitate also for significant code contributions - if needed, we'll help you
+to get the code ready to common standards.
 
 Please refer to the 
 `HyperSpy developer guide <http://hyperspy.org/hyperspy-doc/current/dev_guide/intro.html>`_
@@ -30,6 +33,13 @@ in order to get started and for detailed contributing guidelines.
 The `kikuchypy contributors guide <https://kikuchipy.org/en/stable/contributing.html>`_,
 another HyperSpy extension, also is a valuable resource that can get you
 started and provides useful guidelines.
+
+Reviewing
+---------
+
+As quality assurance, to improve the code, and to ensure a generalized
+functionality, pull requests need to be thoroughly reviewed by at least one
+other member of the development team before being merged.
 
 Documentation
 =============

--- a/lumispy/signals/common_luminescence.py
+++ b/lumispy/signals/common_luminescence.py
@@ -111,8 +111,8 @@ class CommonLumi:
         replaces them by 'counts/s'.
 
         .. deprecated:: 0.2
-          The `exposure` argument will be removed in LumiSpy 1.0, use
-          `integration_time` instead.
+          The `exposure` argument was renamed `integration_time`, and its use
+          will be deprecated in LumiSpy 1.0.
         """
         # Check metadata tags that would prevent scaling
         if self.metadata.Signal.get_item("normalized"):
@@ -127,8 +127,8 @@ class CommonLumi:
             if "exposure" in kwargs:
                 integration_time = kwargs["exposure"]
                 raise DeprecationWarning(
-                    "The `exposure` argument will be "
-                    "removed in LumiSpy 1.0, use `integration_time` instead."
+                    "The `exposure` argument was renamed `integration_time`"
+                    "and its use will be deprecated in LumiSpy 1.0."
                 )
             if self.metadata.has_item(
                 "Acquisition_instrument.Detector.integration_time"
@@ -138,23 +138,10 @@ class CommonLumi:
                         "Acquisition_instrument.Detector.integration_time"
                     )
                 )
-            # following will work only from hyperspy v1.7
-            elif self.original_metadata.has_item("integration_time", full_path=False):
-                integration_time = float(
-                    self.original_metadata.get_item("integration_time", full_path=False)
-                )
-            elif self.original_metadata.has_item("exposure", full_path=False):
-                integration_time = float(
-                    self.original_metadata.get_item("exposure", full_path=False)
-                )
-            elif self.original_metadata.has_item("dwell_time", full_path=False):
-                integration_time = float(
-                    self.original_metadata.get_item("dwell_time", full_path=False)
-                )
             else:
                 raise AttributeError(
-                    "Integration time (exposure) not given and can not be "
-                    "extracted automatically from original_metadata."
+                    "Integration time (exposure) not given and it is not "
+                    "included in the metadata."
                 )
         if inplace:
             s = self

--- a/lumispy/signals/common_luminescence.py
+++ b/lumispy/signals/common_luminescence.py
@@ -124,10 +124,12 @@ class CommonLumi:
 
         # Make sure integration_time is given or contained in metadata
         if integration_time is None:
-            if 'exposure' in kwargs:
-                integration_time = kwargs['exposure']
-                raise DeprecationWarning("The `exposure` argument will be "
-                "removed in LumiSpy 1.0, use `integration_time` instead.")
+            if "exposure" in kwargs:
+                integration_time = kwargs["exposure"]
+                raise DeprecationWarning(
+                    "The `exposure` argument will be "
+                    "removed in LumiSpy 1.0, use `integration_time` instead."
+                )
             if self.metadata.has_item(
                 "Acquisition_instrument.Detector.integration_time"
             ):
@@ -142,9 +144,13 @@ class CommonLumi:
                     self.metadata.get_item("integration_time", full_path=False)
                 )
             elif self.original_metadata.has_item("exposure", full_path=False):
-                integration_time = float(self.metadata.get_item("exposure", full_path=False))
+                integration_time = float(
+                    self.metadata.get_item("exposure", full_path=False)
+                )
             elif self.original_metadata.has_item("dwell_time", full_path=False):
-                integration_time = float(self.metadata.get_item("dwell_time", full_path=False))
+                integration_time = float(
+                    self.metadata.get_item("dwell_time", full_path=False)
+                )
             else:
                 raise AttributeError(
                     "Integration time (exposure) not given and can not be "

--- a/lumispy/signals/common_luminescence.py
+++ b/lumispy/signals/common_luminescence.py
@@ -141,15 +141,15 @@ class CommonLumi:
             # following will work only from hyperspy v1.7
             elif self.original_metadata.has_item("integration_time", full_path=False):
                 integration_time = float(
-                    self.metadata.get_item("integration_time", full_path=False)
+                    self.original_metadata.get_item("integration_time", full_path=False)
                 )
             elif self.original_metadata.has_item("exposure", full_path=False):
                 integration_time = float(
-                    self.metadata.get_item("exposure", full_path=False)
+                    self.original_metadata.get_item("exposure", full_path=False)
                 )
             elif self.original_metadata.has_item("dwell_time", full_path=False):
                 integration_time = float(
-                    self.metadata.get_item("dwell_time", full_path=False)
+                    self.original_metadata.get_item("dwell_time", full_path=False)
                 )
             else:
                 raise AttributeError(

--- a/lumispy/signals/common_luminescence.py
+++ b/lumispy/signals/common_luminescence.py
@@ -111,8 +111,8 @@ class CommonLumi:
         replaces them by 'counts/s'.
 
         .. deprecated:: 0.2
-          The `exposure` argument was renamed `integration_time`, and its use
-          will be deprecated in LumiSpy 1.0.
+          The `exposure` argument was renamed `integration_time`, and it will
+          be removed in LumiSpy 1.0.
         """
         # Check metadata tags that would prevent scaling
         if self.metadata.Signal.get_item("normalized"):
@@ -128,7 +128,7 @@ class CommonLumi:
                 integration_time = kwargs["exposure"]
                 raise DeprecationWarning(
                     "The `exposure` argument was renamed `integration_time`"
-                    "and its use will be deprecated in LumiSpy 1.0."
+                    "and it will be removed in LumiSpy 1.0."
                 )
             if self.metadata.has_item(
                 "Acquisition_instrument.Detector.integration_time"

--- a/lumispy/signals/common_luminescence.py
+++ b/lumispy/signals/common_luminescence.py
@@ -127,7 +127,7 @@ class CommonLumi:
             if "exposure" in kwargs:
                 integration_time = kwargs["exposure"]
                 raise DeprecationWarning(
-                    "The `exposure` argument was renamed `integration_time`"
+                    "The `exposure` argument was renamed `integration_time` "
                     "and it will be removed in LumiSpy 1.0."
                 )
             if self.metadata.has_item(

--- a/lumispy/tests/signals/test_common_luminescence.py
+++ b/lumispy/tests/signals/test_common_luminescence.py
@@ -58,49 +58,63 @@ class TestCommonLumi:
         s1 = LumiSpectrum(np.ones((10, 10, 10)))
         s2 = LumiTransient(np.ones((10, 10, 10, 10)))
         s3 = LumiSpectrum(np.ones((10, 10)))
+        # s31 = LumiSpectrum(np.ones((10, 10)))
+        # s32 = LumiSpectrum(np.ones((10, 10)))
         s4 = LumiSpectrum(np.ones((10)))
-        s2.metadata.set_item("Acquisition_instrument.CL.exposure", 2)
+        s2.metadata.set_item("Acquisition_instrument.Detector.integration_time", 2)
+        s3.metadata.set_item("Acquisition_instrument.Detector.integration_time", 0.5)
+        # use the following instead once hyperspy v1.7 is out (and uncomment extra lines)
         s3.metadata.set_item("Acquisition_instrument.CL.dwell_time", 0.5)
+        # s31.metadata.set_item("Acquisition_instrument.CL.exposure", 1)
+        # s32.metadata.set_item("Acquisition_instrument.CL.integration_time", 5)
         s3.metadata.set_item("Signal.quantity", "Intensity (Counts)")
+        # s31.metadata.set_item("Signal.quantity", "Intensity (Counts)")
+        # s32.metadata.set_item("Signal.quantity", "Intensity (Counts)")
         s4.metadata.set_item("Signal.quantity", "Intensity (counts)")
         s1a = s1.scale_by_exposure(exposure=4)
         s2a = s2.scale_by_exposure()
         s3a = s3.scale_by_exposure()
+        # s31a = s31.scale_by_exposure()
+        # s32a = s32.scale_by_exposure()
         s4a = s4.scale_by_exposure(exposure=0.1)
         assert np.all(s1a.data == 0.25)
         assert np.all(s2a.data == 0.5)
         assert np.all(s3a.data == 2)
+        # assert np.all(s31a.data == 1)
+        # assert np.all(s32a.data == 0.2)
         assert np.all(s4a.data == 10)
         assert s3a.metadata.Signal.quantity == "Intensity (Counts/s)"
+        # assert s31a.metadata.Signal.quantity == "Intensity (Counts/s)"
+        # assert s32a.metadata.Signal.quantity == "Intensity (Counts/s)"
         assert s4a.metadata.Signal.quantity == "Intensity (counts/s)"
         assert s4a.metadata.Signal.scaled == True
         s1.scale_by_exposure(exposure=4, inplace=True)
         s2.scale_by_exposure(inplace=True)
         s3.scale_by_exposure(inplace=True)
+        # s31.scale_by_exposure(inplace=True)
+        # s32.scale_by_exposure(inplace=True)
         s4.scale_by_exposure(exposure=0.1, inplace=True)
         assert s1 == s1a
         assert s2 == s2a
         assert s3 == s3a
+        # assert s31 == s31a
+        # assert s32 == s32a
         assert s4 == s4a
         assert s3.metadata.Signal.quantity == "Intensity (Counts/s)"
+        # assert s31.metadata.Signal.quantity == "Intensity (Counts/s)"
+        # assert s32.metadata.Signal.quantity == "Intensity (Counts/s)"
         assert s4.metadata.Signal.quantity == "Intensity (counts/s)"
         # Test for errors
         s4 = LumiSpectrum(np.ones((10)))
         s4.normalize(inplace=True)
-        with pytest.raises(AttributeError) as excinfo:
+        with pytest.raises(AttributeError, match="Data was normalized and"):
             s4.scale_by_exposure(inplace=True, exposure=0.5)
-        assert str(excinfo.value) == "Data was normalized and cannot be " "scaled."
         s5 = LumiSpectrum(np.ones((10)))
-        with pytest.raises(AttributeError) as excinfo:
+        with pytest.raises(AttributeError, match="can not be extracted"):
             s5.scale_by_exposure(inplace=True)
-        assert (
-            str(excinfo.value) == "Exposure not given and can not be "
-            "extracted automatically from metadata."
-        )
         s5.scale_by_exposure(inplace=True, exposure=0.5)
-        with pytest.raises(AttributeError) as excinfo:
+        with pytest.raises(AttributeError, match="Data was already scaled."):
             s5.scale_by_exposure(inplace=True, exposure=0.5)
-        assert str(excinfo.value) == "Data was already scaled."
 
     def test_normalize(self):
         s1 = LumiSpectrum(np.random.random((10, 10, 10))) * 2

--- a/lumispy/tests/signals/test_common_luminescence.py
+++ b/lumispy/tests/signals/test_common_luminescence.py
@@ -58,51 +58,49 @@ class TestCommonLumi:
         s1 = LumiSpectrum(np.ones((10, 10, 10)))
         s2 = LumiTransient(np.ones((10, 10, 10, 10)))
         s3 = LumiSpectrum(np.ones((10, 10)))
-        # s31 = LumiSpectrum(np.ones((10, 10)))
-        # s32 = LumiSpectrum(np.ones((10, 10)))
+        s31 = LumiSpectrum(np.ones((10, 10)))
+        s32 = LumiSpectrum(np.ones((10, 10)))
         s4 = LumiSpectrum(np.ones((10)))
         s2.metadata.set_item("Acquisition_instrument.Detector.integration_time", 2)
-        s3.metadata.set_item("Acquisition_instrument.Detector.integration_time", 0.5)
-        # use the following instead once hyperspy v1.7 is out (and uncomment extra lines)
-        s3.metadata.set_item("Acquisition_instrument.CL.dwell_time", 0.5)
-        # s31.metadata.set_item("Acquisition_instrument.CL.exposure", 1)
-        # s32.metadata.set_item("Acquisition_instrument.CL.integration_time", 5)
+        s3.original_metadata.set_item("Acquisition_instrument.CL.dwell_time", 0.5)
+        s31.original_metadata.set_item("Acquisition_instrument.CL.exposure", 1)
+        s32.original_metadata.set_item("Acquisition_instrument.CL.integration_time", 5)
         s3.metadata.set_item("Signal.quantity", "Intensity (Counts)")
-        # s31.metadata.set_item("Signal.quantity", "Intensity (Counts)")
-        # s32.metadata.set_item("Signal.quantity", "Intensity (Counts)")
+        s31.metadata.set_item("Signal.quantity", "Intensity (Counts)")
+        s32.metadata.set_item("Signal.quantity", "Intensity (Counts)")
         s4.metadata.set_item("Signal.quantity", "Intensity (counts)")
         s1a = s1.scale_by_exposure(integration_time=4)
         s2a = s2.scale_by_exposure()
         s3a = s3.scale_by_exposure()
-        # s31a = s31.scale_by_exposure()
-        # s32a = s32.scale_by_exposure()
+        s31a = s31.scale_by_exposure()
+        s32a = s32.scale_by_exposure()
         s4a = s4.scale_by_exposure(integration_time=0.1)
         assert np.all(s1a.data == 0.25)
         assert np.all(s2a.data == 0.5)
         assert np.all(s3a.data == 2)
-        # assert np.all(s31a.data == 1)
-        # assert np.all(s32a.data == 0.2)
+        assert np.all(s31a.data == 1)
+        assert np.all(s32a.data == 0.2)
         assert np.all(s4a.data == 10)
         assert s3a.metadata.Signal.quantity == "Intensity (Counts/s)"
-        # assert s31a.metadata.Signal.quantity == "Intensity (Counts/s)"
-        # assert s32a.metadata.Signal.quantity == "Intensity (Counts/s)"
+        assert s31a.metadata.Signal.quantity == "Intensity (Counts/s)"
+        assert s32a.metadata.Signal.quantity == "Intensity (Counts/s)"
         assert s4a.metadata.Signal.quantity == "Intensity (counts/s)"
         assert s4a.metadata.Signal.scaled == True
         s1.scale_by_exposure(integration_time=4, inplace=True)
         s2.scale_by_exposure(inplace=True)
         s3.scale_by_exposure(inplace=True)
-        # s31.scale_by_exposure(inplace=True)
-        # s32.scale_by_exposure(inplace=True)
+        s31.scale_by_exposure(inplace=True)
+        s32.scale_by_exposure(inplace=True)
         s4.scale_by_exposure(integration_time=0.1, inplace=True)
         assert s1 == s1a
         assert s2 == s2a
         assert s3 == s3a
-        # assert s31 == s31a
-        # assert s32 == s32a
+        assert s31 == s31a
+        assert s32 == s32a
         assert s4 == s4a
         assert s3.metadata.Signal.quantity == "Intensity (Counts/s)"
-        # assert s31.metadata.Signal.quantity == "Intensity (Counts/s)"
-        # assert s32.metadata.Signal.quantity == "Intensity (Counts/s)"
+        assert s31.metadata.Signal.quantity == "Intensity (Counts/s)"
+        assert s32.metadata.Signal.quantity == "Intensity (Counts/s)"
         assert s4.metadata.Signal.quantity == "Intensity (counts/s)"
         # Test for errors
         s4 = LumiSpectrum(np.ones((10)))

--- a/lumispy/tests/signals/test_common_luminescence.py
+++ b/lumispy/tests/signals/test_common_luminescence.py
@@ -62,45 +62,21 @@ class TestCommonLumi:
         s32 = LumiSpectrum(np.ones((10, 10)))
         s4 = LumiSpectrum(np.ones((10)))
         s2.metadata.set_item("Acquisition_instrument.Detector.integration_time", 2)
-        s3.original_metadata.set_item("Acquisition_instrument.CL.dwell_time", 0.5)
-        s31.original_metadata.set_item("Acquisition_instrument.CL.exposure", 1)
-        s32.original_metadata.set_item("Acquisition_instrument.CL.integration_time", 5)
-        s3.metadata.set_item("Signal.quantity", "Intensity (Counts)")
-        s31.metadata.set_item("Signal.quantity", "Intensity (Counts)")
-        s32.metadata.set_item("Signal.quantity", "Intensity (Counts)")
         s4.metadata.set_item("Signal.quantity", "Intensity (counts)")
         s1a = s1.scale_by_exposure(integration_time=4)
         s2a = s2.scale_by_exposure()
-        s3a = s3.scale_by_exposure()
-        s31a = s31.scale_by_exposure()
-        s32a = s32.scale_by_exposure()
         s4a = s4.scale_by_exposure(integration_time=0.1)
         assert np.all(s1a.data == 0.25)
         assert np.all(s2a.data == 0.5)
-        assert np.all(s3a.data == 2)
-        assert np.all(s31a.data == 1)
-        assert np.all(s32a.data == 0.2)
         assert np.all(s4a.data == 10)
-        assert s3a.metadata.Signal.quantity == "Intensity (Counts/s)"
-        assert s31a.metadata.Signal.quantity == "Intensity (Counts/s)"
-        assert s32a.metadata.Signal.quantity == "Intensity (Counts/s)"
         assert s4a.metadata.Signal.quantity == "Intensity (counts/s)"
         assert s4a.metadata.Signal.scaled == True
         s1.scale_by_exposure(integration_time=4, inplace=True)
         s2.scale_by_exposure(inplace=True)
-        s3.scale_by_exposure(inplace=True)
-        s31.scale_by_exposure(inplace=True)
-        s32.scale_by_exposure(inplace=True)
         s4.scale_by_exposure(integration_time=0.1, inplace=True)
         assert s1 == s1a
         assert s2 == s2a
-        assert s3 == s3a
-        assert s31 == s31a
-        assert s32 == s32a
         assert s4 == s4a
-        assert s3.metadata.Signal.quantity == "Intensity (Counts/s)"
-        assert s31.metadata.Signal.quantity == "Intensity (Counts/s)"
-        assert s32.metadata.Signal.quantity == "Intensity (Counts/s)"
         assert s4.metadata.Signal.quantity == "Intensity (counts/s)"
         # Test for errors
         s4 = LumiSpectrum(np.ones((10)))
@@ -108,14 +84,14 @@ class TestCommonLumi:
         with pytest.raises(AttributeError, match="Data was normalized and"):
             s4.scale_by_exposure(inplace=True, integration_time=0.5)
         s5 = LumiSpectrum(np.ones((10)))
-        with pytest.raises(AttributeError, match="can not be extracted"):
+        with pytest.raises(AttributeError, match="not included in the"):
             s5.scale_by_exposure(inplace=True)
         s5.scale_by_exposure(inplace=True, integration_time=0.5)
         with pytest.raises(AttributeError, match="Data was already scaled."):
             s5.scale_by_exposure(inplace=True, integration_time=0.5)
         # Deprecation test for exposure argument
         s6 = LumiSpectrum(np.ones((10)))
-        with pytest.raises(DeprecationWarning, match="removed in LumiSpy 1.0"):
+        with pytest.raises(DeprecationWarning, match="deprecated in LumiSpy 1.0"):
             s6.scale_by_exposure(inplace=True, exposure=0.5)
             assert np.all(s6.data == 2)
 

--- a/lumispy/tests/signals/test_common_luminescence.py
+++ b/lumispy/tests/signals/test_common_luminescence.py
@@ -91,7 +91,7 @@ class TestCommonLumi:
             s5.scale_by_exposure(inplace=True, integration_time=0.5)
         # Deprecation test for exposure argument
         s6 = LumiSpectrum(np.ones((10)))
-        with pytest.raises(DeprecationWarning, match="deprecated in LumiSpy 1.0"):
+        with pytest.raises(DeprecationWarning, match="removed in LumiSpy 1.0"):
             s6.scale_by_exposure(inplace=True, exposure=0.5)
             assert np.all(s6.data == 2)
 

--- a/lumispy/tests/signals/test_common_luminescence.py
+++ b/lumispy/tests/signals/test_common_luminescence.py
@@ -71,12 +71,12 @@ class TestCommonLumi:
         # s31.metadata.set_item("Signal.quantity", "Intensity (Counts)")
         # s32.metadata.set_item("Signal.quantity", "Intensity (Counts)")
         s4.metadata.set_item("Signal.quantity", "Intensity (counts)")
-        s1a = s1.scale_by_exposure(exposure=4)
+        s1a = s1.scale_by_exposure(integration_time=4)
         s2a = s2.scale_by_exposure()
         s3a = s3.scale_by_exposure()
         # s31a = s31.scale_by_exposure()
         # s32a = s32.scale_by_exposure()
-        s4a = s4.scale_by_exposure(exposure=0.1)
+        s4a = s4.scale_by_exposure(integration_time=0.1)
         assert np.all(s1a.data == 0.25)
         assert np.all(s2a.data == 0.5)
         assert np.all(s3a.data == 2)
@@ -88,12 +88,12 @@ class TestCommonLumi:
         # assert s32a.metadata.Signal.quantity == "Intensity (Counts/s)"
         assert s4a.metadata.Signal.quantity == "Intensity (counts/s)"
         assert s4a.metadata.Signal.scaled == True
-        s1.scale_by_exposure(exposure=4, inplace=True)
+        s1.scale_by_exposure(integration_time=4, inplace=True)
         s2.scale_by_exposure(inplace=True)
         s3.scale_by_exposure(inplace=True)
         # s31.scale_by_exposure(inplace=True)
         # s32.scale_by_exposure(inplace=True)
-        s4.scale_by_exposure(exposure=0.1, inplace=True)
+        s4.scale_by_exposure(integration_time=0.1, inplace=True)
         assert s1 == s1a
         assert s2 == s2a
         assert s3 == s3a
@@ -108,13 +108,18 @@ class TestCommonLumi:
         s4 = LumiSpectrum(np.ones((10)))
         s4.normalize(inplace=True)
         with pytest.raises(AttributeError, match="Data was normalized and"):
-            s4.scale_by_exposure(inplace=True, exposure=0.5)
+            s4.scale_by_exposure(inplace=True, integration_time=0.5)
         s5 = LumiSpectrum(np.ones((10)))
         with pytest.raises(AttributeError, match="can not be extracted"):
             s5.scale_by_exposure(inplace=True)
-        s5.scale_by_exposure(inplace=True, exposure=0.5)
+        s5.scale_by_exposure(inplace=True, integration_time=0.5)
         with pytest.raises(AttributeError, match="Data was already scaled."):
-            s5.scale_by_exposure(inplace=True, exposure=0.5)
+            s5.scale_by_exposure(inplace=True, integration_time=0.5)
+        # Deprecation test for exposure argument
+        s6 = LumiSpectrum(np.ones((10)))
+        with pytest.raises(DeprecationWarning, match="removed in LumiSpy 1.0"):
+            s6.scale_by_exposure(inplace=True, exposure=0.5)
+            assert np.all(s6.data == 2)
 
     def test_normalize(self):
         s1 = LumiSpectrum(np.random.random((10, 10, 10))) * 2


### PR DESCRIPTION
### Description of the change
- update `scale_by_exposure` according to #109
- some tests can only run with Hyperspy v1.7 (they work locally with the development branch)
- added extra comments in contributors guide

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] docstring updated (if appropriate),
- [x] added tests (partly still commented out),
- [x] activate remaining tests once HyperSpy v1.7 is out,
- [x] added line to CHANGELOG.md,
- [x] ready for review.

### Note
Tests run locally, should work once HyperSpy v1.7 is released.  Merge will need to wait for the release, but can be reviewed already for a speedy release of LumiSpy v0.2 after the HyperSpy release.