### PR TITLE
HyperSpy v1.7 adaptions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Added
 
 Changed
 -------
-- Adapt to accound for the general availability of non-uniform axes with the HyperSpy v1.7 release
+- Account for the general availability of non-uniform axes with the HyperSpy v1.7 release
 - Add python 3.10 build. Remove python 3.6.
 - Fix error in background dimensions that allows compatibility for updated `map` in HyperSpy (failing integration tests)
 - Fix for links in PyPi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,6 @@ Added
 Changed
 -------
 - Adapt to accound for the general availability of non-uniform axes with the HyperSpy v1.7 release
-- Make `LumiTransient` and subclasses 1D and add 2D `LumiTransientSpectrum` classes
 - Add python 3.10 build. Remove python 3.6.
 - Fix error in background dimensions that allows compatibility for updated `map` in HyperSpy (failing integration tests)
 - Fix for links in PyPi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ Added
 
 Changed
 -------
+- Adapt to accound for the general availability of non-uniform axes with the HyperSpy v1.7 release
+- Make `LumiTransient` and subclasses 1D and add 2D `LumiTransientSpectrum` classes
 - Add python 3.10 build. Remove python 3.6.
 - Fix error in background dimensions that allows compatibility for updated `map` in HyperSpy (failing integration tests)
 - Fix for links in PyPi

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -39,7 +39,8 @@ workflows.
 
 .. note::
 
-   This project is under active development. Everyone is welcome to contribute. Please read our (see :ref:`contributing_label`) guidelines and get started!
+   This project is under active development. Everyone is welcome to contribute.
+   Please read our (see :ref:`contributing_label`) guidelines and get started!
 
 Contents
 ========

--- a/doc/source/user_guide/installation.rst
+++ b/doc/source/user_guide/installation.rst
@@ -35,29 +35,6 @@ Now activate the LumiSpy environment and install the package using pip:
 
 Installation is completed! To start using it, check the next section.
 
-.. note::
-
-    **Working with eV instead of wavelength units**
-
-    In order to convert your signal luminescence axes (normally in wavelength in nanometers) to energy units,
-    you will need to reinstall the ``hyperspy`` package to its developing branch ``RELEASE_next_minor``.
-
-    *If you skip this, all LumiSpy functions will work, except the energy conversion.*
-
-    To do that, follow these steps:
-
-    1. Load the anaconda prompt.
-    2. Activate the LumiSpy environment using ``conda activate lumispy``).
-    3. Install ``git`` and reinstall the HyperSpy package running:
-
-    .. code-block:: bash
-
-        (base) conda activate lumispy
-        (lumispy) conda install git -y
-        (lumispy) pip uninstall hyperspy -y
-        (lumispy) pip install git+git://github.com/hyperspy/hyperspy@RELEASE_next_minor
-
-    Now you are ready to use all the functionalites of LumiSpy.
 
 Getting Started
 ===============

--- a/doc/source/user_guide/introduction.rst
+++ b/doc/source/user_guide/introduction.rst
@@ -43,7 +43,7 @@ features that **HyperSpy** provides are:
   interest <https://hyperspy.org/hyperspy-doc/current/user_guide/interactive_operations_ROIs.html>`_
   and a powerful numpy-style `indexing mechanism
   <https://hyperspy.org/hyperspy-doc/current/user_guide/signal.html#indexing>`_,
-- handling of non-uniform data axes (to be included in the v1.7 release).
+- handling of non-uniform data axes (introduced in the v1.7 release).
 
 **LumiSpy** provides in particular:
 

--- a/doc/source/user_guide/signal_axis.rst
+++ b/doc/source/user_guide/signal_axis.rst
@@ -24,9 +24,8 @@ created, and ``jacobian=True/False`` (default is True, see
 
 .. Note::
 
-    The non-uniform axis functionality will be available from HyperSpy v.1.7.
-    If this version is not yet available, you need to use the `development
-    branch <https://github.com/hyperspy/hyperspy>`_.
+    The non-uniform axis functionality was introduced in HyperSpy v.1.7, which
+    is therefore the minimum requirement for LumiSpy.
 
 
 .. _energy_axis-label:

--- a/doc/source/user_guide/signal_axis.rst
+++ b/doc/source/user_guide/signal_axis.rst
@@ -22,11 +22,6 @@ determines whether the current signal object is modified or a new one is
 created, and ``jacobian=True/False`` (default is True, see
 :ref:`jacobian-label`).
 
-.. Note::
-
-    The non-uniform axis functionality was introduced in HyperSpy v.1.7, which
-    is therefore the minimum requirement for LumiSpy.
-
 
 .. _energy_axis-label:
 

--- a/lumispy/signals/cl_spectrum.py
+++ b/lumispy/signals/cl_spectrum.py
@@ -82,12 +82,6 @@ class CLSpectrum(LumiSpectrum):
         **kwargs
     ):
 
-        if not "threshold" in getfullargspec(self.spikes_removal_tool)[0]:
-            raise ImportError(
-                "Spike removal works only "
-                "if the RELEASE_next_minor branch of HyperSpy is used."
-            )
-
         if luminescence_roi is not None and signal_mask is not None:
             raise AttributeError(
                 "Only either `luminescence_roi` or the `signal_mask` can be an input."

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -408,11 +408,6 @@ class LumiSpectrum(Signal1D, CommonLumi):
         >>> from lumispy import LumiSpectrum
         >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
         >>> S1.to_invcm(laser=325)
-
-        Notes
-        -----
-        Using a non-linear axis works only for the RELEASE_next_minor development
-        branch of HyperSpy.    
     """
 
     def to_invcm_relative(self, laser=None, inplace=True, jacobian=True):

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -128,19 +128,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
         >>> from lumispy import LumiSpectrum
         >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
         >>> S1.to_eV()
-
-        Notes
-        -----
-        Using a non-linear axis works only for the RELEASE_next_minor development
-        branch of HyperSpy.
         """
-
-        # Check if non_uniform_axis is available in hyperspy version
-        if not "axis" in getfullargspec(DataAxis)[0]:
-            raise ImportError(
-                "Conversion to energy axis works only "
-                "if the RELEASE_next_minor branch of HyperSpy is used."
-            )
 
         evaxis, factor = axis2eV(self.axes_manager.signal_axes[0])
 
@@ -289,11 +277,6 @@ class LumiSpectrum(Signal1D, CommonLumi):
         >>> from lumispy import LumiSpectrum
         >>> S1 = LumiSpectrum(np.ones(20), DataAxis(axis = np.arange(200,400,10)), ))
         >>> S1.to_invcm()
-
-        Notes
-        -----
-        Using a non-linear axis works only for the RELEASE_next_minor development
-        branch of HyperSpy.    
         """
 
     def to_invcm(self, inplace=True, jacobian=True):
@@ -303,13 +286,6 @@ class LumiSpectrum(Signal1D, CommonLumi):
         %s
         %s
         """
-
-        # Check if non_uniform_axis is available in hyperspy version
-        if not "axis" in getfullargspec(DataAxis)[0]:
-            raise ImportError(
-                "Conversion to wavenumber axis works only"
-                " if the RELEASE_next_minor branch of HyperSpy is used."
-            )
 
         invcmaxis, factor = axis2invcm(self.axes_manager.signal_axes[0])
 
@@ -452,13 +428,6 @@ class LumiSpectrum(Signal1D, CommonLumi):
         %s
         """
 
-        # Check if non_uniform_axis is available in hyperspy version
-        if not "axis" in getfullargspec(DataAxis)[0]:
-            raise ImportError(
-                "Conversion to wavenumber axis works only"
-                " if the RELEASE_next_minor branch of HyperSpy is used."
-            )
-
         # check if laser wavelength is available
         if laser == None:
             if not self.metadata.has_item("Acquisition_instrument.Laser.wavelength"):
@@ -546,7 +515,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
 
         Notes
         -----
-        This function does not work with non-linear axes.
+        This function does not work with non-uniform axes.
         """
         if hasattr(self.metadata.Signal, "background_subtracted"):
             if self.metadata.Signal.background_subtracted is True:

--- a/lumispy/tests/utils/test_axis-conversion.py
+++ b/lumispy/tests/utils/test_axis-conversion.py
@@ -21,7 +21,7 @@ from numpy import arange, ones
 from numpy.testing import assert_allclose
 from pytest import raises, mark, skip, warns
 
-from hyperspy.axes import DataAxis
+from hyperspy.axes import DataAxis,UniformDataAxis
 from lumispy.signals import LumiSpectrum
 from lumispy.utils.axes import (
     nm2eV,
@@ -53,15 +53,6 @@ def test_eV2nm():
 
 
 def test_axis2eV():
-    axis = DataAxis(size=20, offset=200, scale=10)
-
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raises(ImportError, axis2eV, axis)
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     axis = UniformDataAxis(size=20, offset=200, scale=10)
     axis2 = DataAxis(axis=arange(0.2, 0.400, 0.01), units="µm")
     axis3 = DataAxis(axis=arange(1, 2, 0.1), units="eV")
@@ -82,11 +73,6 @@ def test_axis2eV():
 
 
 def test_data2eV():
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     data = 100 * ones(20)
     ax0 = DataAxis(axis=arange(200, 400, 10), units="nm")
     evaxis, factor = axis2eV(ax0)
@@ -99,11 +85,6 @@ def test_data2eV():
 
 
 def test_var2eV():
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     data = 100 * ones(20)
     ax0 = DataAxis(axis=arange(200, 400, 10), units="nm")
     evaxis, factor = axis2eV(ax0)
@@ -114,15 +95,6 @@ def test_var2eV():
 @mark.parametrize(("jacobian"), (True, False))
 @mark.parametrize(("variance"), (True, False, "constant"))
 def test_to_eV(jacobian, variance):
-    axis = DataAxis(size=20, offset=200, scale=10)
-
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raises(ImportError, axis2eV, axis)
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     axis = UniformDataAxis(size=20, offset=200, scale=10)
     data = ones(20)
     S1 = LumiSpectrum(data, axes=(axis.get_axis_dictionary(),))
@@ -211,15 +183,6 @@ def test_to_eV(jacobian, variance):
 
 @mark.parametrize(("jacobian"), (True, False))
 def test_reset_variance_linear_model_eV(jacobian):
-    axis = DataAxis(size=20, offset=200, scale=10)
-
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raises(ImportError, axis2eV, axis)
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     axis = UniformDataAxis(size=20, offset=200, scale=10)
     data = ones(20)
     S1 = LumiSpectrum(data, axes=(axis.get_axis_dictionary(),))
@@ -272,15 +235,6 @@ def test_invcm2nm():
 
 
 def test_axis2invcm():
-    axis = DataAxis(size=20, offset=200, scale=10)
-
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raises(ImportError, axis2invcm, axis)
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     axis = UniformDataAxis(size=21, offset=200, scale=10)
     axis2 = DataAxis(axis=arange(0.2, 0.410, 0.01), units="µm")
     axis3 = DataAxis(axis=arange(1, 2, 0.1), units=r"cm$^{-1}$")
@@ -321,15 +275,6 @@ def test_var2invcm():
 @mark.parametrize(("jacobian"), (True, False))
 @mark.parametrize(("variance"), (True, False, "constant"))
 def test_to_invcm(jacobian, variance):
-    axis = DataAxis(size=20, offset=200, scale=10)
-
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raises(ImportError, axis2invcm, axis)
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     axis = UniformDataAxis(size=20, offset=200, scale=10)
     data = ones(20)
     S1 = LumiSpectrum(data, axes=(axis.get_axis_dictionary(),))
@@ -418,15 +363,6 @@ def test_to_invcm(jacobian, variance):
 
 @mark.parametrize(("jacobian"), (True, False))
 def test_reset_variance_linear_model_invcm(jacobian):
-    axis = DataAxis(size=20, offset=200, scale=10)
-
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raises(ImportError, axis2invcm, axis)
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     axis = UniformDataAxis(size=20, offset=200, scale=10)
     data = ones(20)
     S1 = LumiSpectrum(data, axes=(axis.get_axis_dictionary(),))
@@ -467,15 +403,6 @@ def test_reset_variance_linear_model_invcm(jacobian):
 @mark.parametrize(("jacobian"), (True, False))
 @mark.parametrize(("variance"), (True, False, "constant"))
 def test_to_invcm_relative(jacobian, variance):
-    axis = DataAxis(size=20, offset=200, scale=10)
-
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raises(ImportError, axis2invcm, axis)
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     axis = UniformDataAxis(size=20, offset=200, scale=10)
     data = ones(20)
     S1 = LumiSpectrum(data, axes=(axis.get_axis_dictionary(),))
@@ -564,15 +491,6 @@ def test_to_invcm_relative(jacobian, variance):
 
 @mark.parametrize(("jacobian"), (True, False))
 def test_to_raman_shift(jacobian):
-    axis = DataAxis(size=20, offset=200, scale=10)
-
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raises(ImportError, axis2invcm, axis)
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     axis = UniformDataAxis(size=20, offset=200, scale=10)
     data = ones(20)
     S1 = LumiSpectrum(data, axes=(axis.get_axis_dictionary(),))
@@ -589,15 +507,6 @@ def test_to_raman_shift(jacobian):
 
 
 def test_to_raman_shift_laser():
-    axis = DataAxis(size=20, offset=200, scale=10)
-
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raises(ImportError, axis2invcm, axis)
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
-
     axis = UniformDataAxis(size=20, offset=200, scale=10, units="nm")
     data = ones(20)
     S1 = LumiSpectrum(data, axes=(axis.get_axis_dictionary(),))

--- a/lumispy/tests/utils/test_axis-conversion.py
+++ b/lumispy/tests/utils/test_axis-conversion.py
@@ -21,7 +21,7 @@ from numpy import arange, ones
 from numpy.testing import assert_allclose
 from pytest import raises, mark, skip, warns
 
-from hyperspy.axes import DataAxis,UniformDataAxis
+from hyperspy.axes import DataAxis, UniformDataAxis
 from lumispy.signals import LumiSpectrum
 from lumispy.utils.axes import (
     nm2eV,

--- a/lumispy/tests/utils/test_joinspectra.py
+++ b/lumispy/tests/utils/test_joinspectra.py
@@ -128,10 +128,6 @@ def test_joinspectra_linescan(average, scale, kind):
 @mark.parametrize(("scale"), (True, False))
 @mark.parametrize(("kind"), ("slinear", "linear"))
 def test_joinspectra_nonuniform(average, scale, kind):
-    try:
-        from hyperspy.axes import UniformDataAxis
-    except ImportError:
-        skip("HyperSpy version doesn't support non-uniform axis")
     s1 = LumiSpectrum(arange(32))
     s2 = LumiSpectrum(arange(32) + 25)
     s2.axes_manager.signal_axes[0].offset = 25

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -86,12 +86,6 @@ def axis2eV(ax0):
     dependent permittivity of air. Assumes wavelength in units of nm unless the
     axis units are specifically set to µm.
     """
-    # Check if non_uniform_axis is available in hyperspy version
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raise ImportError(
-            "Conversion to energy axis works only "
-            "if the RELEASE_next_minor branch of HyperSpy is used."
-        )
     if ax0.units == "eV":
         raise AttributeError("Signal unit is already eV.")
     # transform axis, invert direction
@@ -154,13 +148,6 @@ def axis2invcm(ax0):
     r"""Converts given signal axis to wavenumber scale (cm$^{-1}$). Assumes
     wavelength in units of nm unless the axis units are specifically set to µm.
     """
-    # Check if non_uniform_axis is available in hyperspy version
-    if not "axis" in getfullargspec(DataAxis)[0]:
-        raise ImportError(
-            "Conversion to wavenumber axis works only "
-            "if the RELEASE_next_minor branch of HyperSpy is used."
-        )
-
     if ax0.units == r"cm$^{-1}$":
         raise AttributeError(r"Signal unit is already cm$^{-1}$.")
     # transform axis, invert direction

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=[
         "numpy",
         "scipy",
-        "hyperspy >= 1.5.2",  # earlier versions incompatible with numpy >= 1.17.0
+        "hyperspy >= 1.7",  # earlier versions do not provide non-uniform axes
     ],
     extras_require={
         "tests": ["pytest>=5.0"],


### PR DESCRIPTION
### Description of the change
- set HyperSpy v1.7 as minimum requirement
- remove error messages for non-availability of non-uniform axes
- remove conditions in tests
- adapt mentions in the documentation

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] docstring updated (if appropriate),
- [x] updated tests,
- [x] added line to CHANGELOG.md,
- [x] ready for review.

### Note
Tests run locally, should work once HyperSpy v1.7 is released.  Merge will need to wait for the release, but can be reviewed already for a speedy release of LumiSpy v0.2 after the HyperSpy release.
