### PR TITLE
Update warning tests + black

### DIFF
--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -18,7 +18,6 @@
 
 """Signal class for Luminescence spectral data (1D).
 """
-import warnings
 import numpy as np
 from inspect import getfullargspec
 from warnings import warn
@@ -512,7 +511,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
         -----
         This function does not work with non-uniform axes.
         """
-        warnings.warn(
+        warn(
             "The use of `remove_background_from_file` is deprecated and will be removed in LumiSpy 1.0. "
             "Please use `remove_background_signal` from the Signal1D class.",
             DeprecationWarning,

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -512,8 +512,12 @@ class LumiSpectrum(Signal1D, CommonLumi):
         -----
         This function does not work with non-uniform axes.
         """
-        warnings.warn('The use of `remove_background_from_file` is deprecated and will be removed in LumiSpy 1.0. '
-                      'Please use `remove_background_signal` from the Signal1D class.', DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            "The use of `remove_background_from_file` is deprecated and will be removed in LumiSpy 1.0. "
+            "Please use `remove_background_signal` from the Signal1D class.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if hasattr(self.metadata.Signal, "background_subtracted"):
             if self.metadata.Signal.background_subtracted is True:
                 raise RecursionError(

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -512,21 +512,23 @@ class LumiSpectrum(Signal1D, CommonLumi):
         This function does not work with non-uniform axes.
         """
         warn(
-            "The use of `remove_background_from_file` is deprecated and will be removed in LumiSpy 1.0. "
-            "Please use `remove_background_signal` from the Signal1D class.",
+            "The use of `remove_background_from_file` is deprecated and will "
+            "be removed in LumiSpy 1.0. Please use `remove_background_signal` "
+            "from the Signal1D class.",
             DeprecationWarning,
             stacklevel=2,
         )
         if hasattr(self.metadata.Signal, "background_subtracted"):
             if self.metadata.Signal.background_subtracted is True:
                 raise RecursionError(
-                    "You have already removed background once. If you need to remove it again, "
-                    "set the s.metadata.Signal.background_subtracted to False"
+                    "You have already removed background once. If you need to "
+                    "remove it again, set the "
+                    "s.metadata.Signal.background_subtracted to False."
                 )
         elif background is None:
             warn(
-                "Using the Hyperspy specfic `remove_background` function. Use `s.remove_background()` "
-                "instead.",
+                "Using the Hyperspy specfic `remove_background` function. "
+                "Use `s.remove_background()` instead.",
                 category=SyntaxWarning,
             )
             self.remove_background(**kwargs)

--- a/lumispy/tests/signals/test_common_luminescence.py
+++ b/lumispy/tests/signals/test_common_luminescence.py
@@ -136,7 +136,5 @@ class TestCommonLumi:
         assert s3a == s3
         assert s4a == s4
         assert s4.metadata.Signal.quantity == "Normalized intensity"
-        with pytest.warns(UserWarning) as warninfo:
+        with pytest.warns(UserWarning, match="Data was"):
             s1.normalize(inplace=True)
-        assert len(warninfo) == 1
-        assert warninfo[0].message.args[0][:8] == "Data was"

--- a/lumispy/tests/signals/test_luminescence_spectrum.py
+++ b/lumispy/tests/signals/test_luminescence_spectrum.py
@@ -38,7 +38,7 @@ backgrounds = [
 error_backgrounds = [
     ([np.linspace(0, 49, num=10, dtype="float64"), np.ones(50)], AttributeError),
     ([[1, 1], [1, 1], [1, 1]], AttributeError),
-    #([np.linspace(0, 48, num=10, dtype="float64"), np.ones(50)], AttributeError),
+    # ([np.linspace(0, 48, num=10, dtype="float64"), np.ones(50)], AttributeError),
 ]
 
 
@@ -68,10 +68,10 @@ class TestLumiSpectrum:
     def test_warnings(self):
         pytest.importorskip("hyperspy_gui_ipywidgets")
         s = LumiSpectrum(np.ones(50))
-        with pytest.warns(SyntaxWarning, match='Using the Hyperspy') as warninfo:
+        with pytest.warns(SyntaxWarning, match="Using the Hyperspy"):
             s.remove_background_from_file(background=None, display=False)
 
     def test_deprecation_warning(self):
         s = LumiSpectrum(np.ones(50))
-        with pytest.warns(DeprecationWarning, match='deprecated') as warninfo:
+        with pytest.warns(DeprecationWarning, match="deprecated"):
             s.remove_background_from_file(background=backgrounds[0][0])

--- a/lumispy/tests/utils/test_joinspectra.py
+++ b/lumispy/tests/utils/test_joinspectra.py
@@ -29,10 +29,8 @@ from lumispy.signals import LumiSpectrum
 
 def test__n_air():
     wl = arange(800) * 2 + 150
-    with warns(UserWarning) as warninfo:
+    with warns(UserWarning, match="The wavelength"):
         n = _n_air(wl)
-    assert len(warninfo) == 1
-    assert warninfo[0].message.args[0][:14] == "The wavelength"
     assert n[0] == _n_air(185)
     assert n[-1] == _n_air(1700)
     with warns(UserWarning):


### PR DESCRIPTION
Update warning tests to always use `match`.
Fix black formatting (lint failure).

