### PR TITLE
Improve coverage, fix issue with variance conversion

### DIFF
--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -210,14 +210,11 @@ class LumiSpectrum(Signal1D, CommonLumi):
                 if jacobian:
                     # if variance is a numeric value, cast into signal object
                     if isinstance(var, (float, int)):
-                        self.set_noise_variance(
-                            self._deepcopy_with_new_data(
-                                np.ones(self.data.shape) * var,
-                                copy_variance=False,
-                                copy_learning_results=False,
-                            )
+                        var = self._deepcopy_with_new_data(
+                            np.ones(self.data.shape) * var,
+                            copy_variance=False,
+                            copy_learning_results=False,
                         )
-                        var = self.get_noise_variance()
                     # convert
                     s2var = s2._deepcopy_with_new_data(
                         var2eV(
@@ -364,14 +361,11 @@ class LumiSpectrum(Signal1D, CommonLumi):
                 if jacobian:
                     # if variance is a numeric value, cast into signal object
                     if isinstance(var, (float, int)):
-                        self.set_noise_variance(
-                            self._deepcopy_with_new_data(
-                                np.ones(self.data.shape) * var,
-                                copy_variance=False,
-                                copy_learning_results=False,
-                            )
+                        var = self._deepcopy_with_new_data(
+                            np.ones(self.data.shape) * var,
+                            copy_variance=False,
+                            copy_learning_results=False,
                         )
-                        var = self.get_noise_variance()
                     s2var = s2._deepcopy_with_new_data(
                         var2invcm(
                             var.isig[::-1].data,

--- a/lumispy/tests/signals/test_cl_spectrum.py
+++ b/lumispy/tests/signals/test_cl_spectrum.py
@@ -69,6 +69,17 @@ class TestCLSpectrum:
         np.testing.assert_almost_equal(s1.data[1, 0, 1], 1, decimal=5)
         np.testing.assert_almost_equal(s1.data[0, 2, 29], 1, decimal=5)
 
+        s3 = s.remove_spikes(show_diagnosis_histogram=True)
+        hist_data = s._get_spikes_diagnosis_histogram_data(bins=25)
+        expected_data = np.zeros(25)
+        expected_data[0] = 176
+        expected_data[6] = 1
+        expected_data[12] = 2
+        expected_data[-1] = 1
+        np.testing.assert_allclose(hist_data.data, expected_data)
+        np.testing.assert_almost_equal(s3.data[1, 0, 1], 1, decimal=5)
+        np.testing.assert_almost_equal(s3.data[0, 2, 29], 1, decimal=5)
+
         lum_roi = [1, 1]
         s4 = s.remove_spikes(luminescence_roi=lum_roi, threshold=0.5)
         np.testing.assert_almost_equal(s4.data[1, 0, 1], 3, decimal=5)

--- a/lumispy/tests/signals/test_common_luminescence.py
+++ b/lumispy/tests/signals/test_common_luminescence.py
@@ -59,7 +59,7 @@ class TestCommonLumi:
         s2 = LumiTransientSpectrum(np.ones((10, 10, 10, 10)))
         s4 = LumiSpectrum(np.ones((10)))
         s2.metadata.set_item("Acquisition_instrument.Detector.integration_time", 2)
-        s2.metadata.set_item("Signal.quantity", "Intensity (Counts/s)")
+        s2.metadata.set_item("Signal.quantity", "Intensity (Counts)")
         s4.metadata.set_item("Signal.quantity", "Intensity (counts)")
         s1a = s1.scale_by_exposure(integration_time=4)
         s2a = s2.scale_by_exposure()

--- a/lumispy/tests/signals/test_common_luminescence.py
+++ b/lumispy/tests/signals/test_common_luminescence.py
@@ -57,11 +57,9 @@ class TestCommonLumi:
     def test_scale_by_exposure(self):
         s1 = LumiSpectrum(np.ones((10, 10, 10)))
         s2 = LumiTransientSpectrum(np.ones((10, 10, 10, 10)))
-        s3 = LumiSpectrum(np.ones((10, 10)))
-        s31 = LumiSpectrum(np.ones((10, 10)))
-        s32 = LumiSpectrum(np.ones((10, 10)))
         s4 = LumiSpectrum(np.ones((10)))
         s2.metadata.set_item("Acquisition_instrument.Detector.integration_time", 2)
+        s2.metadata.set_item("Signal.quantity", "Intensity (Counts/s)")
         s4.metadata.set_item("Signal.quantity", "Intensity (counts)")
         s1a = s1.scale_by_exposure(integration_time=4)
         s2a = s2.scale_by_exposure()
@@ -69,6 +67,7 @@ class TestCommonLumi:
         assert np.all(s1a.data == 0.25)
         assert np.all(s2a.data == 0.5)
         assert np.all(s4a.data == 10)
+        assert s2a.metadata.Signal.quantity == "Intensity (Counts/s)"
         assert s4a.metadata.Signal.quantity == "Intensity (counts/s)"
         assert s4a.metadata.Signal.scaled == True
         s1.scale_by_exposure(integration_time=4, inplace=True)
@@ -77,6 +76,7 @@ class TestCommonLumi:
         assert s1 == s1a
         assert s2 == s2a
         assert s4 == s4a
+        assert s2.metadata.Signal.quantity == "Intensity (Counts/s)"
         assert s4.metadata.Signal.quantity == "Intensity (counts/s)"
         # Test for errors
         s4 = LumiSpectrum(np.ones((10)))

--- a/lumispy/tests/utils/test_axis-conversion.py
+++ b/lumispy/tests/utils/test_axis-conversion.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from inspect import getfullargspec
 from numpy import arange, ones
 from numpy.testing import assert_allclose
 from pytest import raises, mark, skip, warns
@@ -530,22 +529,17 @@ def test_to_raman_shift_laser():
     assert_allclose(S1.data, S2.data, 5e-4)
 
 
-@mark.parametrize(("axis_class"), (DataAxis, UniformDataAxis))
-def test_solve_grating_equation(axis_class):
+def test_solve_grating_equation():
     with warns(SyntaxWarning, match="(not in pixel units)"):
-        axis = axis_class(size=20, offset=200, scale=10, units="nm")
+        axis = UniformDataAxis(size=20, offset=200, scale=10, units="nm")
         solve_grating_equation(axis, 3, -20, 300, 25, 600, 150)
 
-    if axis_class is UniformDataAxis:
-        axis1 = axis_class(
-            size=10,
-            offset=200,
-            scale=10,
-        )
-        axis2 = axis_class(size=10, offset=200, scale=10, units="px")
-    else:
-        axis1 = axis_class(axis=arange(10) * 10 + 200, units="px")
-        axis2 = axis_class(axis=arange(10) * 10 + 200)
+    axis1 = UniformDataAxis(
+        size=10,
+        offset=200,
+        scale=10,
+    )
+    axis2 = UniformDataAxis(size=10, offset=200, scale=10, units="px")
 
     nm_axis1 = solve_grating_equation(axis1, 3, -20, 300, 25, 600, 150)
     with warns(UserWarning, match="(range exceeds)"):

--- a/lumispy/tests/utils/test_axis-conversion.py
+++ b/lumispy/tests/utils/test_axis-conversion.py
@@ -544,8 +544,8 @@ def test_solve_grating_equation(axis_class):
         )
         axis2 = axis_class(size=10, offset=200, scale=10, units="px")
     else:
-        axis1 = axis_class(axis=arange(10)*10+200, units="px")
-        axis2 = axis_class(axis=arange(10)*10+200)
+        axis1 = axis_class(axis=arange(10) * 10 + 200, units="px")
+        axis2 = axis_class(axis=arange(10) * 10 + 200)
 
     nm_axis1 = solve_grating_equation(axis1, 3, -20, 300, 25, 600, 150)
     with warns(UserWarning, match="(range exceeds)"):

--- a/lumispy/tests/utils/test_axis-conversion.py
+++ b/lumispy/tests/utils/test_axis-conversion.py
@@ -530,25 +530,22 @@ def test_to_raman_shift_laser():
     assert_allclose(S1.data, S2.data, 5e-4)
 
 
-def test_solve_grating_equation():
-    # Check which version of hyperspy is installed
-    if "scale" in getfullargspec(DataAxis)[0]:
-        axis_class = DataAxis
-    else:
-        from hyperspy.axes import UniformDataAxis
-
-        axis_class = UniformDataAxis
-
+@mark.parametrize(("axis_class"), (DataAxis, UniformDataAxis))
+def test_solve_grating_equation(axis_class):
     with warns(SyntaxWarning, match="(not in pixel units)"):
         axis = axis_class(size=20, offset=200, scale=10, units="nm")
         solve_grating_equation(axis, 3, -20, 300, 25, 600, 150)
 
-    axis1 = axis_class(
-        size=10,
-        offset=200,
-        scale=10,
-    )
-    axis2 = axis_class(size=10, offset=200, scale=10, units="px")
+    if axis_class is UniformDataAxis:
+        axis1 = axis_class(
+            size=10,
+            offset=200,
+            scale=10,
+        )
+        axis2 = axis_class(size=10, offset=200, scale=10, units="px")
+    else:
+        axis1 = axis_class(axis=arange(10)*10+200, units="px")
+        axis2 = axis_class(axis=arange(10)*10+200)
 
     nm_axis1 = solve_grating_equation(axis1, 3, -20, 300, 25, 600, 150)
     with warns(UserWarning, match="(range exceeds)"):

--- a/lumispy/tests/utils/test_joinspectra.py
+++ b/lumispy/tests/utils/test_joinspectra.py
@@ -94,6 +94,10 @@ def test_joinspectra_length1():
     assert s.data[-1] == 58
     with raises(ValueError, match="Averaging can not be performed for r=1."):
         s = join_spectra([s1, s2], r=1, average=True, scale=True)
+    s1.axes_manager[0].convert_to_non_uniform_axis()
+    s2.axes_manager[0].convert_to_non_uniform_axis()
+    s = join_spectra([s1, s2], r=1, average=True, scale=True)
+    assert s.data[-1] == 58
 
 
 def test_joinspectra_errors():

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -357,10 +357,7 @@ def join_spectra(S, r=50, scale=True, average=False, kind="slinear"):
                     kind=kind,
                 )
                 length1 = axis.axis[ind1 - r : ind1 + 1].size
-                if length1 == 1:
-                    grad1 = 0
-                else:
-                    grad1 = 0.5 / (length1 - 1)
+                grad1 = 0.5 / (length1 - 1)
                 vect1 = np.arange(length1)
                 length2 = axis2.axis[ind2 : ind2 + r].size
                 if length2 == 1:
@@ -481,10 +478,7 @@ def solve_grating_equation(
     # Create axis object to return
     scale = (l_max - l_min) / ch
 
-    if "scale" in getfullargspec(DataAxis)[0]:
-        axis_class = DataAxis
-    else:
-        axis_class = UniformDataAxis
+    axis_class = UniformDataAxis
 
     axis_nm = axis_class(
         scale=scale,

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -357,14 +357,12 @@ def join_spectra(S, r=50, scale=True, average=False, kind="slinear"):
                     kind=kind,
                 )
                 length1 = axis.axis[ind1 - r : ind1 + 1].size
-                print(length1)
                 if length1 == 1:
                     grad1 = 0
                 else:
                     grad1 = 0.5 / (length1 - 1)
                 vect1 = np.arange(length1)
                 length2 = axis2.axis[ind2 : ind2 + r].size
-                print(length2)
                 if length2 == 1:
                     grad2 = 0.5
                 else:

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -357,12 +357,14 @@ def join_spectra(S, r=50, scale=True, average=False, kind="slinear"):
                     kind=kind,
                 )
                 length1 = axis.axis[ind1 - r : ind1 + 1].size
+                print(length1)
                 if length1 == 1:
                     grad1 = 0
                 else:
                     grad1 = 0.5 / (length1 - 1)
                 vect1 = np.arange(length1)
                 length2 = axis2.axis[ind2 : ind2 + r].size
+                print(length2)
                 if length2 == 1:
                     grad2 = 0.5
                 else:


### PR DESCRIPTION
### Description of the change
- Fix some of the missing coverage mentioned in #133.
- Fix issue with `to_eV` and `to_invcm` changing the variance of the original signal when the variance is a single `int/float` and `inplace=False` (turned up as `inplace=True` was not covered by the test despite it should have been).
- Remove remnants of old HyperSpy axes scheme in `solve_grating_equation` that turned up as a missing coverage for the line checking the axes type version.


### Progress of the PR
- [x] Change implemented,
- [x] ready for review.
