### PR TITLE
Remove deprecated `create-release` action and use `softprops/action-gh-release` instead

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
       - name: Get version (on tag)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Changed
 -------
 - `s.remove_negative` now defaults to `inplace=False` (previously `True`)
 
+Maintenance
+-----------
+- Use ``softprops/action-gh-release`` action instead of deprecated ``create-release`` . Pin action to a commit SHA.
+
 2022-04-29 - version 0.2
 ========================
 Added


### PR DESCRIPTION
xref https://github.com/LumiSpy/lumispy/issues/76

### Progress of the PR
- [x] Remove deprecated `create-release` action and use `softprops/action-gh-release` instead,
- [x] pinned actions to a commit SHA,
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [n/a] added tests,
- [x] added line to CHANGELOG.md,
- [x] ready for review.



