### PR TITLE
Fix slicing of energy/wavenumber signal with isig

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 30
     env:
       MPLBACKEND: agg
-      PIP_ARGS: --upgrade --use-feature=2020-resolver -e
+      PIP_ARGS: --upgrade -e
       PYTEST_ARGS: --pyargs lumispy
       PYTEST_ARGS_COVERAGE: 
     strategy:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Added
 Changed
 -------
 - Fix conversion to Raman shift (relative wavenumber) and make ``jacobian=False`` default; ``fix inplace=False`` for axis conversions
+- Fix ``to_eV`` and ``to_invcm``, as slicing with `.isig[]` was failing on converted signals
 - ``s.remove_negative`` now defaults to ``inplace=False`` (previously ``True``)
 
 Maintenance

--- a/lumispy/tests/utils/test_axis-conversion.py
+++ b/lumispy/tests/utils/test_axis-conversion.py
@@ -189,6 +189,12 @@ def test_to_eV(jacobian, variance):
         assert S1.metadata.has_item("Signal.Noise_properties.variance") == False
 
 
+def test_eV_slicing():
+    S = LumiSpectrum(arange(100), axes=[{"axis": arange(100) + 300}])
+    S.to_eV(inplace=True)
+    S.isig[3.251:4.052]
+
+
 @mark.parametrize(("jacobian"), (True, False))
 def test_reset_variance_linear_model_eV(jacobian):
     axis = UniformDataAxis(size=20, offset=200, scale=10)
@@ -378,6 +384,12 @@ def test_to_invcm(jacobian, variance):
         assert S1.metadata.has_item("Signal.Noise_properties.variance") == False
 
 
+def test_invcm_slicing():
+    S = LumiSpectrum(arange(100), axes=[{"axis": arange(100) + 300}])
+    S.to_invcm(inplace=True)
+    S.isig[26000.0:30000.0]
+
+
 @mark.parametrize(("jacobian"), (True, False))
 def test_reset_variance_linear_model_invcm(jacobian):
     axis = UniformDataAxis(size=20, offset=200, scale=10)
@@ -555,6 +567,12 @@ def test_to_raman_shift_laser():
     assert S2.axes_manager[0].size == 20
     assert S1.axes_manager[0].axis[0] == S2.axes_manager[0].axis[0]
     assert_allclose(S1.data, S2.data, 5e-4)
+
+
+def test_ramanshift_slicing():
+    S = LumiSpectrum(arange(100), axes=[{"axis": arange(100) + 300}])
+    S.to_raman_shift(inplace=True, laser=295)
+    S.isig[3000.0:8000.0]
 
 
 def test_solve_grating_equation():

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -87,10 +87,10 @@ def axis2eV(ax0):
         raise AttributeError("Signal unit is already eV.")
     # transform axis, invert direction
     if ax0.units == "µm":
-        evaxis = nm2eV(1000 * ax0.axis)[::-1].astype("float64")
+        evaxis = nm2eV(1000 * ax0.axis)[::-1].astype("float")
         factor = 1e3  # correction factor for intensity
     else:
-        evaxis = nm2eV(ax0.axis)[::-1].astype("float64")
+        evaxis = nm2eV(ax0.axis)[::-1].astype("float")
         factor = 1e6
     axis = DataAxis(axis=evaxis, name="Energy", units="eV", navigate=False)
     return axis, factor
@@ -149,10 +149,10 @@ def axis2invcm(ax0):
         raise AttributeError(r"Signal unit is already cm$^{-1}$.")
     # transform axis, invert direction
     if ax0.units == "µm":
-        invcmaxis = nm2invcm(1000 * ax0.axis)[::-1].astype("float64")
+        invcmaxis = nm2invcm(1000 * ax0.axis)[::-1].astype("float")
         factor = 1e4  # correction factor for intensity
     else:
-        invcmaxis = nm2invcm(ax0.axis)[::-1].astype("float64")
+        invcmaxis = nm2invcm(ax0.axis)[::-1].astype("float")
         factor = 1e7
     axis = DataAxis(
         axis=invcmaxis, name="Wavenumber", units=r"cm$^{-1}$", navigate=False

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -87,10 +87,10 @@ def axis2eV(ax0):
         raise AttributeError("Signal unit is already eV.")
     # transform axis, invert direction
     if ax0.units == "µm":
-        evaxis = nm2eV(1000 * ax0.axis)[::-1]
+        evaxis = nm2eV(1000 * ax0.axis)[::-1].astype("float64")
         factor = 1e3  # correction factor for intensity
     else:
-        evaxis = nm2eV(ax0.axis)[::-1]
+        evaxis = nm2eV(ax0.axis)[::-1].astype("float64")
         factor = 1e6
     axis = DataAxis(axis=evaxis, name="Energy", units="eV", navigate=False)
     return axis, factor
@@ -149,10 +149,10 @@ def axis2invcm(ax0):
         raise AttributeError(r"Signal unit is already cm$^{-1}$.")
     # transform axis, invert direction
     if ax0.units == "µm":
-        invcmaxis = nm2invcm(1000 * ax0.axis)[::-1]
+        invcmaxis = nm2invcm(1000 * ax0.axis)[::-1].astype("float64")
         factor = 1e4  # correction factor for intensity
     else:
-        invcmaxis = nm2invcm(ax0.axis)[::-1]
+        invcmaxis = nm2invcm(ax0.axis)[::-1].astype("float64")
         factor = 1e7
     axis = DataAxis(
         axis=invcmaxis, name="Wavenumber", units=r"cm$^{-1}$", navigate=False


### PR DESCRIPTION
### Description of the change
Fixes #155.

`.isig[]` was failing on signals converted using `to_eV()` or `to_invcm()`.

For tests to run, deprecated `--use-feature=2020-resolver` had to be removed from `PIP_ARGS` in `workflows/tests.yml`

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] added tests,
- [x] added line to CHANGELOG.md,
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```
import hyperspy.api as hs
S = hs.signals.Signal1D(np.arange(100),axes=[{'axis': np.arange(100)+300}])
S.set_signal_type("CL")
S.to_eV(inplace=True)
S.isig[3.251:4.052]
```