### PR TITLE
Simplify axes conversion code

### DIFF
--- a/lumispy/tests/utils/test_axis_conversion.py
+++ b/lumispy/tests/utils/test_axis_conversion.py
@@ -75,11 +75,11 @@ def test_data2eV():
     data = 100 * ones(20)
     ax0 = DataAxis(axis=arange(200, 400, 10), units="nm")
     evaxis, factor = axis2eV(ax0)
-    evdata = data2eV(data, factor, ax0, evaxis.axis)
+    evdata = data2eV(data, factor, evaxis.axis, ax0)
     assert_allclose(evdata[0], 12.271168)
     ax0 = DataAxis(axis=arange(0.2, 0.4, 0.01), units="µm")
     evaxis, factor = axis2eV(ax0)
-    evdata = data2eV(data, factor, ax0, evaxis.axis)
+    evdata = data2eV(data, factor, evaxis.axis, ax0)
     assert_allclose(evdata[0], 12.271168e-3)
 
 
@@ -87,7 +87,7 @@ def test_var2eV():
     data = 100 * ones(20)
     ax0 = DataAxis(axis=arange(200, 400, 10), units="nm")
     evaxis, factor = axis2eV(ax0)
-    evvar = var2eV(data, factor, ax0, evaxis.axis)
+    evvar = var2eV(data, factor, evaxis.axis, ax0)
     assert_allclose(evvar[0], 1.5058156)
 
 

--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -96,7 +96,7 @@ def axis2eV(ax0):
     return axis, factor
 
 
-def data2eV(data, factor, ax0, evaxis):
+def data2eV(data, factor, evaxis, ax0):
     """The intensity is converted from counts/nm (counts/µm) to counts/meV by
     doing a Jacobian transformation, see e.g. Mooney and Kambhampati, J. Phys.
     Chem. Lett. 4, 3316 (2013). Ensures that integrated signals are still
@@ -114,7 +114,7 @@ def data2eV(data, factor, ax0, evaxis):
         return data * factor * c.h * c.c / (c.e * _n_air(ax0.axis[::-1]) * evaxis**2)
 
 
-def var2eV(variance, factor, ax0, evaxis):
+def var2eV(variance, factor, evaxis, ax0):
     """The variance is converted doing a squared Jacobian renormalization to
     match with the transformation of the data.
     """
@@ -160,7 +160,7 @@ def axis2invcm(ax0):
     return axis, factor
 
 
-def data2invcm(data, factor, invcmaxis):
+def data2invcm(data, factor, invcmaxis, ax0=None):
     r"""The intensity is converted from counts/nm (counts/µm) to
     counts/cm$^{-1}$ by doing a Jacobian transformation, see e.g. Mooney and
     Kambhampati, J. Phys. Chem. Lett. 4, 3316 (2013). Ensures that integrated
@@ -169,7 +169,7 @@ def data2invcm(data, factor, invcmaxis):
     return data * factor / (invcmaxis**2)
 
 
-def var2invcm(variance, factor, invcmaxis):
+def var2invcm(variance, factor, invcmaxis, ax0=None):
     r"""The variance is converted doing a squared Jacobian renormalization to
     match with the transformation of the data.
     """


### PR DESCRIPTION
### Description of the change
Addresses point 1 in #152.
The axis conversion code was hard to read as routines were repeated for different situations, therefore
- reduced the differences between `inplace=True/False` cases
- and created a generalized utility function to combine code that is universal to the conversions and then call the correct subfunctions

Paves the way for more generalized unit conversion handling (i.e. any conversion between nm, eV and cm^-1).

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [x] added tests,
- [ ] added line to CHANGELOG.md,
- [x] ready for review.


