### PR TITLE
Replace imgmath by mathjax sphinx-extension

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Changed
 
 Maintenance
 -----------
-- Replace `sphinx.ext.imgmath` by `sphinx.ext.mathjax` to fix the math rendering in the ReadTheDocs build
+- Replace ``sphinx.ext.imgmath`` by ``sphinx.ext.mathjax`` to fix the math rendering in the *ReadTheDocs* build
 
 2022-11-02 - version 0.2.1
 ==========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Changed
   for integrity check as `it replaces LGTM
   <https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/>`_
 
+Maintenance
+-----------
+- Replace `sphinx.ext.imgmath` by `sphinx.ext.mathjax` to fix the math rendering in the ReadTheDocs build
+
 2022-11-02 - version 0.2.1
 ==========================
 Added

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,7 +24,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
-    "sphinx.ext.imgmath",
+    "sphinx.ext.mathjax",
     "sphinx.ext.graphviz",
     "sphinx.ext.autosummary",
     "sphinx_toggleprompt",


### PR DESCRIPTION
### Requirements
As brought up in #166, math is not rendering any more in the ReadTheDocs.
AS brought up by @hakonanes in https://github.com/hyperspy/hyperspy/pull/3050#issuecomment-1386765990 `sphinx.ext.mathjax` should be working, while `sphinx.ext.imgmath` seems to be broken (in both HyperSpy and LumiSpy).
Therefore replacing the extension.

Fixes #166

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] added line to CHANGELOG.md,
- [x] ready for review.
