### PR TITLE
Add signal tools page to documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -47,7 +47,7 @@ Contents
 ========
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: User Guide
 
    user_guide/installation.rst
@@ -57,10 +57,11 @@ Contents
    user_guide/fitting_luminescence.rst
    user_guide/utilities.rst
    user_guide/metadata_structure.rst
+   user_guide/bibliography.rst
 
 .. toctree::
    :maxdepth: 2
-   :caption: API References
+   :caption: API reference
 
    api/modules.rst
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -53,6 +53,7 @@ Contents
    user_guide/installation.rst
    user_guide/introduction.rst
    user_guide/signal_axis.rst
+   user_guide/signal_tools.rst
    user_guide/fitting_luminescence.rst
    user_guide/utilities.rst
    user_guide/metadata_structure.rst

--- a/doc/source/user_guide/bibliography.rst
+++ b/doc/source/user_guide/bibliography.rst
@@ -1,0 +1,20 @@
+.. _bibliography:
+
+Bibliography
+************
+
+.. [Mooney] J. Mooney and P. Kambhampati, The Journal of
+    Physical Chemistry Letters **4**, 3316 (2013).
+    `doi:10.1021/jz401508t <https://doi.org/10.1021/jz401508t>`_
+
+.. [Peck] E.R. Peck and K. Reeder, J. Opt. Soc. Am. **62**, 958
+    (1972). `doi:10.1364/JOSA.62.000958 <https://doi.org/10.1364/JOSA.62.000958>`_
+
+.. [Pfueller] C. Pfüller, Dissertation, HU Berlin, p. 28 (2011). 
+    `doi:10.18452/16360 <https://doi.org/10.18452/16360>`_
+
+.. [Tappy] N. Tappy, A. Fontcuberta i Morral and C. Monachon, Rev. Sci. Instrum. 93,
+   053702 (2022). `doi:10.1063/5.0080486 <https://doi.org/10.1063/5.0080486>`_
+
+.. [Wang] Y. Wang and P. D. Townsend, J. Luminesc. **142**, 202
+    (2013). `doi:10.1016/j.jlumin.2013.03.052 <https://doi.org/10.1016/j.jlumin.2013.03.052>`_

--- a/doc/source/user_guide/fitting_luminescence.rst
+++ b/doc/source/user_guide/fitting_luminescence.rst
@@ -3,12 +3,12 @@
 Fitting luminescence data
 *************************
 
-LumiSpy is compatible with `HyperSpy model fitting 
-<https://hyperspy.org/hyperspy-doc/current/user_guide/model.html>`_.
+LumiSpy is compatible with :external+hyperspy:ref:`HyperSpy model fitting 
+<user_guide/model>`.
 It can fit using both `uniform and and non-uniform axes
 <https://hyperspy.org/hyperspy-doc/current/user_guide/axes.html#types-of-data-axes>`_ 
-(e.g. energy scale). A general introduction can be found in the `HyperSpy user guide
-<https://hyperspy.org/hyperspy-doc/current/user_guide/model.html>`_.
+(e.g. energy scale). A general introduction can be found in the
+:external+hyperspy:ref:`HyperSpy user guide <user_guide/model>`.
 
 TODO: Note on advantages of fitting signals in the ``eV`` axis (not restricted
 to Gaussians). See e.g. [Wang]__

--- a/doc/source/user_guide/fitting_luminescence.rst
+++ b/doc/source/user_guide/fitting_luminescence.rst
@@ -10,8 +10,12 @@ It can fit using both `uniform and and non-uniform axes
 (e.g. energy scale). A general introduction can be found in the
 :external+hyperspy:ref:`HyperSpy user guide <user_guide/model>`.
 
-TODO: Note on advantages of fitting signals in the ``eV`` axis (not restricted
-to Gaussians). See e.g. [Wang]__
+.. Note::
+    The :ref:`jacobian` may affect the shape, in particular of broader peaks.
+    It is therefore highly recommended to convert luminescence spectra from
+    wavelength to the :ref:`energy axis <energy_axis>` prior to any fitting
+    to obtain the true emission energy.
+    See e.g. [Wang]_ and [Mooney]_.
 
 TODO: Show how to extract the *modeled signal* with all/one component.
 
@@ -24,10 +28,7 @@ Signal variance (noise)
 =======================
 
 TODO: Documentation on variance handling in the context of fitting,
-in particular using :external:py:meth:`hyperspy.signal.BaseSignal.estimate_poissonian_noise_variance()`
-
-.. rubric:: References
-
-.. [Wang]_ Y. Wang and P. D. Townsend, J. Luminesc. **142**, 202
-    (2013). `doi:10.1016/j.jlumin.2013.03.052 <https://doi.org/10.1016/j.jlumin.2013.03.052>`_
-
+in particular using :external:py:meth:`estimate_poissonian_noise_variance()
+<hyperspy.signal.BaseSignal.estimate_poissonian_noise_variance>`
+ 
+See [Tappy]_

--- a/doc/source/user_guide/installation.rst
+++ b/doc/source/user_guide/installation.rst
@@ -21,7 +21,7 @@ To install LumiSpy, you have the following options (independent of the operating
 Installation using conda
 ========================
 
-Follow these 3 steps to install LumiSpy using **conda**.
+Follow these 3 steps to install LumiSpy using **conda** and start using it.
 
 1. Creating a conda environment
 -------------------------------
@@ -30,8 +30,8 @@ LumiSpy requires Python 3 and ``conda`` -- we suggest using the Python 3 version
 of `Miniconda <https://conda.io/miniconda.html/>`_.
 
 We recommend creating a new environment for the LumiSpy package (or installing
-it in the `HyperSpy <https://hyperspy.org>`_ environment, if you have one already).
-To create a new environment:
+it in the `HyperSpy <https://hyperspy.org/hyperspy-doc/current/user_guide/install.html#installation-using-conda>`_ 
+environment, if you have one already). To create a new environment:
 
 1. Load the anaconda prompt.
 2. Run the following command:

--- a/doc/source/user_guide/installation.rst
+++ b/doc/source/user_guide/installation.rst
@@ -10,10 +10,9 @@ To install LumiSpy, you have the following options (independent of the operating
    (recommended if you do not use *python* for anything else).
 2. :ref:`conda` (recommended if you are also working with other *python* packages).
 3. :ref:`pip`.
-4. Installing the development version from `GitHub <https://github.com/LumiSpy/lumispy/>`_, 
-   refer to the appropriate section in the `HyperSpy user guide
-   <https://hyperspy.org/hyperspy-doc/current/user_guide/install.html#install-development-version>`_
-   (replacing ``hyperspy`` by ``lumispy``).
+4. Installing the development version from `GitHub <https://github.com/LumiSpy/lumispy/>`_.
+   Refer to the appropriate section in the :external+hyperspy:ref:`HyperSpy user guide
+   <install-dev>` (replacing ``hyperspy`` by ``lumispy``).
 
 
 .. _conda:
@@ -30,7 +29,7 @@ LumiSpy requires Python 3 and ``conda`` -- we suggest using the Python 3 version
 of `Miniconda <https://conda.io/miniconda.html/>`_.
 
 We recommend creating a new environment for the LumiSpy package (or installing
-it in the `HyperSpy <https://hyperspy.org/hyperspy-doc/current/user_guide/install.html#installation-using-conda>`_ 
+it in the :external+hyperspy:ref:`HyperSpy <anaconda-install>` 
 environment, if you have one already). To create a new environment:
 
 1. Load the anaconda prompt.
@@ -57,8 +56,8 @@ Installation is completed! To start using it, check the next section.
 
 .. Note::
 
-   If you run into trouble, check the more detailed documentation in the `HyperSpy user guide
-   <https://hyperspy.org/hyperspy-doc/current/user_guide/install.html#installation-using-conda>`__.
+   If you run into trouble, check the more detailed documentation in the
+   :external+hyperspy:ref:`HyperSpy user guide <anaconda-install>`.
 
 
 3. Getting Started

--- a/doc/source/user_guide/introduction.rst
+++ b/doc/source/user_guide/introduction.rst
@@ -1,3 +1,6 @@
+.. _HyperSpy: https://hyperspy.org
+.. |HyperSpy| replace:: **HyperSpy** 
+
 .. _introduction:
 
 Introduction
@@ -16,46 +19,48 @@ measurements, such as absorption or transmission spectroscopy, scanning optical
 near field miscroscopy (SNOM), as well as fourier-transform infrared
 spectroscopy (FTIR).
 
-**LumiSpy** is an extension to the python package **`HyperSpy <https://hyperspy.org>`_**
+**LumiSpy** is an extension to the python package |HyperSpy|_
 that facilitates hyperspectral data analysis, i.e. maps or linescans where a
 spectrum is collected at each pixel. Or more general, multidimensional datasets
-that can be described as multidimensional arrays of a given signal. Notable 
-features that **HyperSpy** provides are:
+that can be described as multidimensional arrays of a given signal.
+
+Notable features that **HyperSpy** provides are:
 
 - `base signal classes <https://hyperspy.org/hyperspy-doc/current/user_guide/signal.html>`_
   for the handling of (multidimensional) spectral data,
-- the necessary tools for loading `various data file formats
-  <https://hyperspy.org/hyperspy-doc/current/user_guide/io.html>`_ with a focus
-  on electron microscopy
-- analytical tools that exploit the multidimensionality of datasets,
+- the necessary tools for loading :external+hyperspy:ref:`various data file formats
+  <io>`,
+- `analytical tools <https://hyperspy.org/hyperspy-doc/current/user_guide/signal1d.html>`_
+  that exploit the multidimensionality of datasets,
 - a user-friendly and powerful framework for `model fitting
   <https://hyperspy.org/hyperspy-doc/current/user_guide/model.html>`_ that
   provides many standard functions and can be easily extended to custom ones,
-- `machine learning <https://hyperspy.org/hyperspy-doc/current/user_guide/mva.html>`_
-  algorithms that can be useful e.g. for denoising data,
-- efficient handling of `big datasets,
-  <https://hyperspy.org/hyperspy-doc/current/user_guide/big_data.html>`_,
-- functions for `data visualization 
-  <https://hyperspy.org/hyperspy-doc/current/user_guide/visualisation.html>`_
+- :external+hyperspy:ref:`machine learning <ml-label>`
+  algorithms that can be useful, e.g. for denoising data,
+- efficient handling of :external+hyperspy:ref:`big datasets <big-data-label>`,
+- functions for :external+hyperspy:ref:`data visualization  <visualization-label>`
   both to evaluate datasets during the analysis and provide interactive
-  operation for certain functions, as well as for plotting of data.
-- extracting subsets of data from multidimensional datasets via `regions of
-  interest <https://hyperspy.org/hyperspy-doc/current/user_guide/interactive_operations_ROIs.html>`_
-  and a powerful numpy-style `indexing mechanism
-  <https://hyperspy.org/hyperspy-doc/current/user_guide/signal.html#indexing>`_,
-- handling of non-uniform data axes (introduced in the v1.7 release).
+  operation for certain functions, as well as for plotting of data,
+- extracting subsets of data from multidimensional datasets via 
+  :external+hyperspy:ref:`regions of interest <roi-label>` and a powerful
+  numpy-style :external+hyperspy:ref:`indexing mechanism <signal.indexing>`,
+- handling of :external+hyperspy:ref:`non-uniform data axes <Axes_types>`
+  (introduced in the `v1.7 release 
+  <https://hyperspy.org/hyperspy-doc/current/user_guide/changes.html#hyperspy-1-7-0-2022-04-26>`_).
 
 **LumiSpy** provides in particular:
 
 - additional :ref:`signal_types` specifically for luminescence spectra and
   transients,
-- transformation to :ref:`signal_axis` for use of other units, such as
-  electron Volt and wavenumbers (Raman shift),
-- various utility functions useful in luminescence spectroscopy data analysis,
-  such as joining multiple spectra along the signal axis, normalizing data, etc.
+- transformation to :ref:`non-uniform signal axes <signal_axis>` for use of other
+  common units, such as eV (electron volt) and wavenumbers (Raman shift),
+- additional :ref:`signal tools <signal_tools>` such as data normalization and scaling,
+- various :ref:`utility functions <utilities>` useful in luminescence spectroscopy
+  data analysis, such as joining multiple spectra along the signal axis, 
+  unit conversion, etc.
 
 **LumiSpy** should facilitate an easy and reproducible analysis of single
-spectra or spectral images
+spectra or spectral images.
 
 
 .. _signal_types:
@@ -64,16 +69,16 @@ Signal types
 ============
 
 As an extension to HyperSpy, LumiSpy provides several signal types extending the
-`base classes available in HyperSpy
-<https://hyperspy.org/hyperspy-doc/current/user_guide/signal.html>`_. When
-the LumiSpy library is installed, these additional signal types are directly
-available to HyperSpy. To print all available specialised
-:external:py:class:`hyperspy.signal.BaseSignal` subclasses installed in your
-system call the :external:py:func:`hyperspy.utils.print_known_signal_types`
+:external+hyperspy:ref:`base classes available in HyperSpy
+<signal_subclasses_table-label>`. When the LumiSpy library is installed, these
+additional signal types are directly available to HyperSpy. To print all available
+specialised :external:py:class:`hyperspy.signal.BaseSignal` subclasses installed
+in your system call the :external:py:func:`hyperspy.utils.print_known_signal_types`
 function:
 
 .. code-block:: python
 
+    >>> import hyperspy.api as hs
     >>> hs.print_known_signal_types()
 
 The different subclasses are characterized by the ``signal_type`` metadata
@@ -85,25 +90,25 @@ signal types (or inheriting) signal types.
 
 .. table:: LumiSpy subclasses and their basic attributes.
 
-    +-----------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  BaseSignal subclass                                            | signal_dimension |  signal_type  |  dtype  |  aliases                                                                  |
-    +=================================================================+==================+===============+=========+===========================================================================+
-    |  :py:class:`~.signals.luminescence_spectrum.LumiSpectrum`       |        1         |  Luminescence |  real   | LuminescenceSpectrum                                                      |
-    +-----------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.cl_spectrum.CLSpectrum`                   |        1         |       CL      |  real   | CLSpectrum, cathodoluminescence                                           |
-    +-----------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.cl_spectrum.CLSEMSpectrum`                |        1         |     CL_SEM    |  real   | CLSEM, cathodoluminescence SEM                                            |
-    +-----------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.cl_spectrum.CLSTEMSpectrum`               |        1         |    CL_STEM    |  real   | CLSTEM, cathodoluminescence STEM                                          |
-    +-----------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.el_spectrum.ELSpectrum`                   |        1         |       EL      |  real   | ELSpectrum, electroluminescence                                           |
-    +-----------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.pl_spectrum.PLSpectrum`                   |        1         |       PL      |  real   | PLSpectrum, photoluminescence                                             |
-    +-----------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.luminescence_transient.LumiTransient`     |        1         |   Transient   |  real   | TRLumi, TR luminescence, time-resolved luminescence                       |
-    +-----------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.luminescence_transientspec.LumiTransient` |        2         | TransientSpec |  real   | TRLumiSpec, TR luminescence spectrum, time-resolved luminescence spectrum |
-    +-----------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  BaseSignal subclass                                                    | signal_dimension |  signal_type  |  dtype  |  aliases                                                                  |
+    +=========================================================================+==================+===============+=========+===========================================================================+
+    |  :py:class:`~.signals.luminescence_spectrum.LumiSpectrum`               |        1         |  Luminescence |  real   | LumiSpectrum, LuminescenceSpectrum                                        |
+    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :py:class:`~.signals.cl_spectrum.CLSpectrum`                           |        1         |       CL      |  real   | CLSpectrum, cathodoluminescence                                           |
+    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :py:class:`~.signals.cl_spectrum.CLSEMSpectrum`                        |        1         |     CL_SEM    |  real   | CLSEM, cathodoluminescence SEM                                            |
+    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :py:class:`~.signals.cl_spectrum.CLSTEMSpectrum`                       |        1         |    CL_STEM    |  real   | CLSTEM, cathodoluminescence STEM                                          |
+    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :py:class:`~.signals.el_spectrum.ELSpectrum`                           |        1         |       EL      |  real   | ELSpectrum, electroluminescence                                           |
+    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :py:class:`~.signals.pl_spectrum.PLSpectrum`                           |        1         |       PL      |  real   | PLSpectrum, photoluminescence                                             |
+    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :py:class:`~.signals.luminescence_transient.LumiTransient`             |        1         |   Transient   |  real   | TRLumi, TR luminescence, time-resolved luminescence                       |
+    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :py:class:`~.signals.luminescence_transientspec.LumiTransientSpectrum` |        2         | TransientSpec |  real   | TRLumiSpec, TR luminescence spectrum, time-resolved luminescence spectrum |
+    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
 
 The hierarchy of the LumiSpy signal types and their inheritance from HyperSpy
 is summarized in the following diagram:
@@ -127,8 +132,9 @@ Where are we heading?
 =====================
 
 LumiSpy is under active development, and as a user-driven project, we welcome
-contributions (see :ref:`contributing_label`) to the code and documentation
-from any other users.
+contributions (see :ref:`contributing_label`) to the code and documentation,
+but also bug reports and feature requests from any other users. Don't hesitate
+to join the discussions!
 
 Currrently, we have implemented the base functionality that extends 
 `HyperSpy's capabilities <https://hyperspy.org/hyperspy-doc/current/index.html>`_

--- a/doc/source/user_guide/introduction.rst
+++ b/doc/source/user_guide/introduction.rst
@@ -26,14 +26,14 @@ that can be described as multidimensional arrays of a given signal.
 
 Notable features that **HyperSpy** provides are:
 
-- `base signal classes <https://hyperspy.org/hyperspy-doc/current/user_guide/signal.html>`_
+- :external+hyperspy:ref:`base signal classes <user_guide/signal>`
   for the handling of (multidimensional) spectral data,
 - the necessary tools for loading :external+hyperspy:ref:`various data file formats
   <io>`,
-- `analytical tools <https://hyperspy.org/hyperspy-doc/current/user_guide/signal1d.html>`_
+- :external+hyperspy:ref:`analytical tools <user_guide/signal1d >`
   that exploit the multidimensionality of datasets,
-- a user-friendly and powerful framework for `model fitting
-  <https://hyperspy.org/hyperspy-doc/current/user_guide/model.html>`_ that
+- a user-friendly and powerful framework for :external+hyperspy:ref:`model fitting
+  <model-label>` that
   provides many standard functions and can be easily extended to custom ones,
 - :external+hyperspy:ref:`machine learning <ml-label>`
   algorithms that can be useful, e.g. for denoising data,
@@ -45,8 +45,8 @@ Notable features that **HyperSpy** provides are:
   :external+hyperspy:ref:`regions of interest <roi-label>` and a powerful
   numpy-style :external+hyperspy:ref:`indexing mechanism <signal.indexing>`,
 - handling of :external+hyperspy:ref:`non-uniform data axes <Axes_types>`
-  (introduced in the `v1.7 release 
-  <https://hyperspy.org/hyperspy-doc/current/user_guide/changes.html#hyperspy-1-7-0-2022-04-26>`_).
+  (introduced in the :external+hyperspy:ref:`v1.7 release 
+  <changes_1.7.0>`).
 
 **LumiSpy** provides in particular:
 

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -15,11 +15,11 @@ the ones for leaves are not capitalized. When a leaf contains a quantity that
 is not dimensionless, the units can be given in an extra leaf with the same
 label followed by the ``_units`` suffix.
 
-Besides directly accesing the metadata tree structure, e.g.
+Besides directly accessing the metadata tree structure, e.g.
 ``s.metadata.Signal.signal_type``, the HyperSpy methods
-:external:py:meth:`hyperspy.misc.utils.DictionaryTreeBrowser.set_item`,
-:external:py:meth:`hyperspy.misc.utils.DictionaryTreeBrowser.has_item` and
-:external:py:meth:`hyperspy.misc.utils.DictionaryTreeBrowser.get_item`
+:external:py:meth:`set_item() <hyperspy.misc.utils.DictionaryTreeBrowser.set_item>`,
+:external:py:meth:`has_item() <hyperspy.misc.utils.DictionaryTreeBrowser.has_item>` and
+:external:py:meth:`get_item() <hyperspy.misc.utils.DictionaryTreeBrowser.get_item>`
 can be used to add to, search for and read from items in the metadata tree,
 respectively.
 

--- a/doc/source/user_guide/metadata_structure.rst
+++ b/doc/source/user_guide/metadata_structure.rst
@@ -3,11 +3,10 @@
 LumiSpy metadata structure
 **************************
 
-LumiSpy extends the `HyperSpy metadata structure
-<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_
+LumiSpy extends the :external+hyperspy:ref:`HyperSpy metadata structure
+<metadata_structure>`
 with conventions for metadata specific to its signal types. Refer to the
-`HyperSpy metadata documentation
-<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html>`_
+:external+hyperspy:ref:`HyperSpy metadata documentation <user_guide/metadata_structure>`
 for general metadata fields.
 
 The metadata of any **signal objects** is stored in the `metadata` attribute,
@@ -119,7 +118,7 @@ quantity
     required, for example 'Intensity (counts/s)'.
 
 See `HyperSpy-Metadata-Signal
-<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#sample>`_
+<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#sample>`__
 for additional fields.
 
 Acquisition Instrument

--- a/doc/source/user_guide/signal_axis.rst
+++ b/doc/source/user_guide/signal_axis.rst
@@ -141,18 +141,3 @@ the noise properties
     :external:py:meth:`hyperspy.signal.BaseSignal.estimate_poissonian_noise_variance`
     prior to the transformation.
 
-
-.. rubric:: References
-
-.. [Pfueller] C. Pfüller, Dissertation, HU Berlin, p. 28 (2011). 
-    `doi:10.18452/16360 <https://doi.org/10.18452/16360>`_
-
-.. [Peck] E.R. Peck and K. Reeder, J. Opt. Soc. Am. **62**, 958
-    (1972). `doi:10.1364/JOSA.62.000958 <https://doi.org/10.1364/JOSA.62.000958>`_
-
-.. [Mooney] J. Mooney and P. Kambhampati, The Journal of
-    Physical Chemistry Letters **4**, 3316 (2013).
-    `doi:10.1021/jz401508t <https://doi.org/10.1021/jz401508t>`_
-
-.. [Wang] Y. Wang and P. D. Townsend, J. Luminesc. **142**, 202
-    (2013). `doi:10.1016/j.jlumin.2013.03.052 <https://doi.org/10.1016/j.jlumin.2013.03.052>`_

--- a/doc/source/user_guide/signal_tools.rst
+++ b/doc/source/user_guide/signal_tools.rst
@@ -1,0 +1,118 @@
+.. _signal_tools:
+
+Signal tools
+************
+
+This section summarizes functions operating on the signal data. Besides those
+implemented in LumiSpy, it highlights functions from HyperSpy that are
+particularly useful for luminescence spectroscopy data.
+
+
+.. _scale_normalize:
+
+Scaling and normalizing signal data
+===================================
+
+For comparative plotting or a detailed analysis, the intensity of spectra may
+need to be either scaled by the respective integration times or
+normalized. The luminescence signal classes provide these functionalities in the
+methods :py:meth:`~.signals.common_luminescence.CommonLumi.scale_by_exposure` and 
+:py:meth:`~.signals.common_luminescence.CommonLumi.normalize`.
+
+Both functions can operate directly on the signal (``inplace=True``), but as default
+a new signal is returned.
+
+The **scaling** function can use the ``integration_time`` (unit: seconds) provided in the
+:ref:`metadata_structure` (``metadata.Acqusition_instrument.Detector.integration_time``).
+Otherwise, the appropriate parameter has to be passed to the function.
+
+.. code-block:: python
+
+    >>> scaled = s.scale_by_exposure(integration_time=0.5, inplace=True)
+
+**Normalization** is performed for the pixel with maximum intensity, Alternatively,
+the parameter ``pos`` in calibrated units of the signal axis can be given to
+normalize the intensity at this position. Normalization may be convenient for
+plotting, but should usually not be performed on signals used as input for further
+analysis (therefore the default is ``inplace=False``). 
+
+.. code-block:: python
+
+    >>> s.normalize(pos=450)
+
+.. _peak_props:
+
+Peak positions and properties
+=============================
+
+.. _find_peaks:
+
+Peak identification
+-------------------
+
+HyperSpy provides functions to finde the positions of maxima or minima in a
+dataset:
+
+- ``indexmax()`` - return the index of the maximum value along a given axis.
+- ``indexmin()`` - return the index of the minimum value along a given axis.
+- ``valuemax()`` - return the position of the maximum value along a given axis in
+  calibrated units.
+- ``valuemin()`` - return the position of the minimum value along a given axis in
+  calibrated units.
+
+These functions take the `axis` keyword to define along which axis to perform the
+operation.
+
+A much more powerful method to identify peaks is using the peak finding routine
+based on the downward zero-crossings of the first derivative of a signal:
+:external+hyperspy:meth:`find_peaks1D_ohaver <hyperspy._signals.signal1d.Signal1D.find_peaks1D_ohaver>`.
+
+All of these functions can be performed for a subset of the dataset:
+
+.. code-block:: python
+
+    >>> peaks = s.find_peaks1D_ohaver()
+    >>> peaks = s.isig[100:-100].find_peaks1D_ohaver()
+
+.. _peak_width:
+
+Peak Width
+----------
+
+For asymmetric peaks, `fitted functions <fitting_luminescence>` may not provide
+an accurate description of the peak, in particular the peak width. The function
+:external+hyperspy:meth:`estimate_peak_width <hyperspy._signals.signal1d.Signal1D.estimate_peak_width>`
+determines the width of a peak at a certain fraction of its maximum value.
+
+
+Signal statistics and analytical operations
+===========================================
+
+Standard statistical operations can be performed on the data or a subset of the
+data, notably these include ``max``, ``min``, ``sum``, ``mean``, ``std``, ``var``.
+
+Integration along a specified signal axis is performed using the function 
+``integrate1D()``.
+
+These functions take the ``axis`` keyword to define along which axis to perform the
+operation.
+
+.. code-block:: python
+
+    >>> area = s.integrate1D(axis=0)
+
+.. _remove_negative:
+
+Replacing negative data values
+==============================
+
+Log-scale plotting fails in the presence of negative values in the dataset 
+(e.g. introduced after background removal). In this case, the utility function
+:py:meth:`~.signals.common_luminescence.CommonLumi.remove_negative` replaces
+all negative values in the data array by a ``basevalue`` (default ``basevalue=1``).
+The default operational mode is ``inplace=False`` (a new signal object is returned).
+
+.. code-block:: python
+
+    >>> s.remove_negative(0.1)
+

--- a/doc/source/user_guide/signal_tools.rst
+++ b/doc/source/user_guide/signal_tools.rst
@@ -50,22 +50,28 @@ Peak positions and properties
 Peak identification
 -------------------
 
-HyperSpy provides functions to finde the positions of maxima or minima in a
+HyperSpy provides functions to find the positions of maxima or minima in a
 dataset:
 
-- ``indexmax()`` - return the index of the maximum value along a given axis.
-- ``indexmin()`` - return the index of the minimum value along a given axis.
-- ``valuemax()`` - return the position of the maximum value along a given axis in
+- :external+hyperspy:meth:`indexmax() <hyperspy.signal.BaseSignal.indexmax>` - 
+  return the index of the maximum value along a given axis.
+- :external+hyperspy:meth:`indexmin() <hyperspy.signal.BaseSignal.indexmin>` - 
+  return the index of the minimum value along a given axis.
+- :external+hyperspy:meth:`valuemax() <hyperspy.signal.BaseSignal.valuemax>` - 
+  return the position/coordinates of the maximum value along a given axis in
   calibrated units.
-- ``valuemin()`` - return the position of the minimum value along a given axis in
+- :external+hyperspy:meth:`valuemin() <hyperspy.signal.BaseSignal.valuemin>` - 
+  return the position/coordinates of the minimum value along a given axis in
   calibrated units.
 
-These functions take the `axis` keyword to define along which axis to perform the
-operation.
+These functions take the ``axis`` keyword to define along which axis to perform
+the operation and return a new signal containing the result.
 
-A much more powerful method to identify peaks is using the peak finding routine
+A much more powerful method to identify peaks is using the **peak finding routine**
 based on the downward zero-crossings of the first derivative of a signal:
-:external+hyperspy:meth:`find_peaks1D_ohaver <hyperspy._signals.signal1d.Signal1D.find_peaks1D_ohaver>`.
+:external+hyperspy:meth:`find_peaks1D_ohaver() <hyperspy._signals.signal1d.Signal1D.find_peaks1D_ohaver>`.
+This function can find multiple peaks in a dataset and has a number of parameters
+for fine-tuning the sensitivity, etc.
 
 All of these functions can be performed for a subset of the dataset:
 
@@ -79,27 +85,48 @@ All of these functions can be performed for a subset of the dataset:
 Peak Width
 ----------
 
-For asymmetric peaks, `fitted functions <fitting_luminescence>` may not provide
+For asymmetric peaks, :ref:`fitted functions <fitting_luminescence>` may not provide
 an accurate description of the peak, in particular the peak width. The function
-:external+hyperspy:meth:`estimate_peak_width <hyperspy._signals.signal1d.Signal1D.estimate_peak_width>`
-determines the width of a peak at a certain fraction of its maximum value.
+:external+hyperspy:meth:`estimate_peak_width() <hyperspy._signals.signal1d.Signal1D.estimate_peak_width>`
+determines the **width of a peak** at a certain fraction of its maximum value. The
+default value ``factor=0.5`` returns the full width at half maximum (FWHM).
+
+.. code-block:: python
+
+    >>> s.remove_background()
+    >>> width = s.estimate_peak_width(factor=0.3)
+
 
 
 Signal statistics and analytical operations
 ===========================================
 
-Standard statistical operations can be performed on the data or a subset of the
-data, notably these include ``max``, ``min``, ``sum``, ``mean``, ``std``, ``var``.
+**Standard statistical operations** can be performed on the data or a subset of the
+data, notably these include 
+:external+hyperspy:meth:`max() <hyperspy.signal.BaseSignal.max>`,
+:external+hyperspy:meth:`min() <hyperspy.signal.BaseSignal.min>`,
+:external+hyperspy:meth:`sum() <hyperspy.signal.BaseSignal.sum>`,
+:external+hyperspy:meth:`mean() <hyperspy.signal.BaseSignal.mean>`,
+:external+hyperspy:meth:`std() <hyperspy.signal.BaseSignal.std>`, and
+:external+hyperspy:meth:`var() <hyperspy.signal.BaseSignal.var>`. Variations of
+all these functions exist that ignore missing values (NaN) if present, e.g.
+:external+hyperspy:meth:`nanmax() <hyperspy.signal.BaseSignal.mnanax>`.
 
-Integration along a specified signal axis is performed using the function 
-``integrate1D()``.
+**Integration** along a specified signal axis is performed using the function 
+:external+hyperspy:meth:`integrate1D() <hyperspy.signal.BaseSignal.integrate1D()>`.
 
-These functions take the ``axis`` keyword to define along which axis to perform the
-operation.
+The numerical **derivative** of a signal can be calculated using the function
+:external+hyperspy:meth:`derivative() <hyperspy.signal.BaseSignal.derivative()>`,
+while the *n*-th order **discrete difference** can be calculated using
+:external+hyperspy:meth:`diff() <hyperspy.signal.BaseSignal.diff()>`.
+
+These functions take the ``axis`` keyword to define along which axis to perform
+the operation and return a new signal containing the result:
 
 .. code-block:: python
 
     >>> area = s.integrate1D(axis=0)
+
 
 .. _remove_negative:
 

--- a/doc/source/user_guide/utilities.rst
+++ b/doc/source/user_guide/utilities.rst
@@ -34,8 +34,8 @@ Utilities for spectral maps
 
 The function :py:meth:`~.signals.common_luminescence.CommonLumi.crop_edges`
 removes the specified number of pixels from all four edges of a spectral map.
-It is a convenience wrapper for the ``inav`` `method in HyperSpy
-<https://hyperspy.org/hyperspy-doc/current/user_guide/signal.html#indexing>`_.
+It is a convenience wrapper for the ``inav`` :external+hyperspy:ref:`method in
+HyperSpy <signal.indexing>`.
 
 .. code-block:: python
 

--- a/doc/source/user_guide/utilities.rst
+++ b/doc/source/user_guide/utilities.rst
@@ -27,55 +27,6 @@ signals in the range of +/- 50 pixels around the centre of the overlapping regio
     >>> s = lum.join_spectra((s1,s2))
 
 
-.. _scale_normalize:
-
-Scaling and normalizing signal data
-===================================
-
-For comparative plotting or a detailed analysis, the intensity of spectra may
-need to be either scaled by the respective integration times or
-normalized. The luminescence signal classes provide these functionalities in the
-methods :py:meth:`~.signals.common_luminescence.CommonLumi.scale_by_exposure` and 
-:py:meth:`~.signals.common_luminescence.CommonLumi.normalize`.
-
-Both functions can operate directly on the signal (``inplace=True``), but as default
-a new signal is returned.
-
-The **scaling** function can use the ``integration_time`` (unit: seconds) provided in the
-:ref:`metadata_structure` (``metadata.Acqusition_instrument.Detector.integration_time``).
-Otherwise, the appropriate parameter has to be passed to the function.
-
-.. code-block:: python
-
-    >>> scaled = s.scale_by_exposure(integration_time=0.5, inplace=True)
-
-**Normalization** is performed for the pixel with maximum intensity, Alternatively,
-the parameter ``pos`` in calibrated units of the signal axis can be given to
-normalize the intensity at this position. Normalization may be convenient for
-plotting, but should usually not be performed on signals used as input for further
-analysis (therefore the default is ``inplace=False``). 
-
-.. code-block:: python
-
-    >>> s.normalize(pos=450)
-
-
-.. _remove_negative:
-
-Replacing negative data values
-==============================
-
-Log-scale plotting fails in the presence of negative values in the dataset 
-(e.g. introduced after background removal). In this case, the utility function
-:py:meth:`~.signals.common_luminescence.CommonLumi.remove_negative` replaces
-all negative values in the data array by a ``basevalue`` (default ``basevalue=1``).
-The default operational mode is ``inplace=False`` (a new signal object is returned).
-
-.. code-block:: python
-
-    >>> s.remove_negative(0.1)
-
-
 .. _spectral_map_utils:
 
 Utilities for spectral maps
@@ -114,7 +65,6 @@ index of air.
 
 Solving the grating equation
 ============================
-
 
 The function :py:func:`~.utils.axes.solve_grating_equation` follows the
 conventions described in the tutorial from 


### PR DESCRIPTION
### Requirements
Split `signal tools` page out of the `utilities page in the user guide. Add some important HyperSpy functions.
Some additional small improvements to the documentation.

Closes #171.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] update user guide (if appropriate),
- [x] ready for review.
