### PR TITLE
Reduce frequency of dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "actions/*"
+        update-types: ["version-update:semver-minor"]
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
### Description of the change
Ignore patch and minor releases for "actions/*" packages on the dependabot checks to avoid overly frequent adaptation of the code.

### Progress of the PR
- [x] Update dependabot.yml
