### PR TITLE
Correct links in docs

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,43 @@
+name: Documentation
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # This build is to make PR comments for the sphinx warning and check if
+    # web links are not broken 
+    name: Check links and make PR comments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        name: Install Python
+        with:
+          python-version: '3.11'
+
+      - name: Install build docs
+        shell: bash -l {0}
+        run: |
+          pip install .[build-doc]
+
+      # Add sphinx warnings as PR comments
+      - uses: sphinx-doc/sphinx-problem-matcher@master
+      - name: Build documentation
+        shell: bash -l {0}
+        run: |
+          cd doc
+          make SPHINXOPTS="-W --keep-going" html
+
+      - uses: actions/upload-artifact@v4
+        with:
+          path: doc/_build/html/
+          name: doc_html
+
+      - name: Check links
+        shell: bash -l {0}
+        run: |
+          cd doc
+          make linkcheck

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ UNRELEASED
 Changed
 -------
 
+Maintenance
+-----------
+- Fix intersphinx links to documentation of HyperSpy 2.0 and add linkchecker workflow
+- Align supported python versions (3.8-3.12) to HyperSpy 2.0 
 
 .. _changes_0.2.2:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,7 +52,7 @@ The LumiSpy documentation consists of three elements:
 - The `documentation <https://docs.lumispy.org>`_ written using `Sphinx
   <https://www.sphinx-doc.org/en/master/>`_ and hosted on `Read the Docs
   <https://docs.lumispy.org>`_. The source is part of the `GitHub repository
-  <https://github.com/LumiSpy/lumispy/tree/main/doc/source>`_.
+  <https://github.com/LumiSpy/lumispy/tree/main/doc>`_.
 - A set of curated Jupyter notebooks in the `LumiSpy demos repository
   <https://github.com/lumispy/lumispy-demos>`_ on GitHub that provide tutorials and example
   workflows.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,10 +31,11 @@ extensions = [
 ]
 
 intersphinx_mapping = {
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "exspy": ("https://hyperspy.org/exspy/", None),
     "hyperspy": ("https://hyperspy.org/hyperspy-doc/current/", None),
-    "rsciio": ("https://hyperspy.org/rosettasciio/", None),
     "kikuchipy": ("https://kikuchipy.org/en/latest/", None),
+    "rsciio": ("https://hyperspy.org/rosettasciio/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
 }
 intersphinx_disabled_domains = ["std"]
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -27,7 +27,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.graphviz",
     "sphinx.ext.autosummary",
-    "sphinx_toggleprompt",
+    "sphinx_copybutton",
 ]
 
 intersphinx_mapping = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,6 +39,11 @@ intersphinx_mapping = {
 }
 intersphinx_disabled_domains = ["std"]
 
+linkcheck_ignore = [
+    "https://doi.org/10.1021/jz401508t",  # 403 Client Error: Forbidden for url
+    "https://github.com/LumiSpy/lumispy/security/code-scanning",  # 404 Client Error: Not Found for url (even though page exists)
+]
+
 # imgmath: Sphinx allows use of LaTeX in the html documentation, but not directly. It is first rendered to an image.
 # You can add here whatever preamble you are used to adding to your LaTeX document.
 imgmath_latex_preamble = r"""

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -27,12 +27,14 @@ Welcome to LumiSpy's documentation!
 .. _DOI: https://doi.org/10.5281/zenodo.4640445
 
 **LumiSpy** is a Python package extending the functionality for multi-dimensional
-data analysis provided by the `HyperSpy <https://hyperspy.org/>`_ library. It is
-aimed at helping with the analysis of luminescence spectroscopy data
+data analysis provided by the `HyperSpy <https://hyperspy.org/>`_ library. **LumiSpy**
+is aimed at helping with the analysis of luminescence spectroscopy data
 (cathodoluminescence, photoluminescence, electroluminescence, Raman, SNOM).
+Reading and writing of data from many relevant file types is provided by the
+library `RosettaSciIO <https://hyperspy.org/rosettasciio>`_.
 
-Check out the :ref:`installation` section for further information, including
-how to start using this project.
+Check out the :ref:`installation` section for further information on how to
+start using **LumiSpy**.
 
 Complementing this documentation, the `LumiSpy Demos <https://github.com/LumiSpy/lumispy-demos>`_
 repository contains curated Jupyter notebooks to provide tutorials and exemplary
@@ -40,8 +42,8 @@ workflows.
 
 .. note::
 
-   This project is under active development. Everyone is welcome to contribute.
-   Please read our:ref:`contributing_label` guidelines and get started!
+   **LumiSpy** is under active development. Everyone is welcome to contribute.
+   Please read our :ref:`contributing_label` guidelines and get started!
 
 Contents
 ========

--- a/doc/user_guide/fitting_luminescence.rst
+++ b/doc/user_guide/fitting_luminescence.rst
@@ -3,12 +3,12 @@
 Fitting luminescence data
 *************************
 
-LumiSpy is compatible with :external+hyperspy:doc:`HyperSpy model fitting 
-<user_guide/model>`.
+LumiSpy is compatible with :external+hyperspy:ref:`HyperSpy model fitting 
+<model-label>`.
 It can fit using both :external+hyperspy:ref:`uniform and and non-uniform axes
 <Axes_types>` 
 (e.g. energy scale). A general introduction can be found in the
-:external+hyperspy:doc:`HyperSpy user guide <user_guide/model>`.
+:external+hyperspy:ref:`HyperSpy user guide <model-label>`.
 
 A detailed example is given in the ``Fitting_tutorial`` in the 
 `HyperSpy demos repository <https://github.com/hyperspy/hyperspy-demos>`_.
@@ -32,7 +32,7 @@ Signal variance (noise)
 =======================
 
 TODO: Documentation on variance handling in the context of fitting,
-in particular using :external:py:meth:`estimate_poissonian_noise_variance()
-<hyperspy.signal.BaseSignal.estimate_poissonian_noise_variance>`
+in particular using :external:meth:`estimate_poissonian_noise_variance()
+<hyperspy.api.signals.BaseSignal.estimate_poissonian_noise_variance>`
  
 For a detailed discussion, see [Tappy]_

--- a/doc/user_guide/installation.rst
+++ b/doc/user_guide/installation.rst
@@ -26,7 +26,7 @@ Follow these 3 steps to install LumiSpy using **conda** and start using it.
 -------------------------------
 
 LumiSpy requires Python 3 and ``conda`` -- we suggest using the Python 3 version
-of `Miniconda <https://conda.io/miniconda.html/>`_.
+of `Miniconda <https://conda.io/miniconda.html>`_.
 
 We recommend creating a new environment for the LumiSpy package (or installing
 it in the :external+hyperspy:ref:`HyperSpy <anaconda-install>` 
@@ -84,8 +84,8 @@ and modify to perform many common analyses.
 Installation using pip
 ========================
 
-Alternatively, you can also find LumiSpy in the `Python Package Index (PyPI) <pypi.org>`_
-and install it using (requires ``pip``):
+Alternatively, you can also find LumiSpy in the `Python Package Index (PyPI)
+<https://pypi.org/search/?q=lumispy>`_ and install it using (requires ``pip``):
 
 .. code-block:: bash
 

--- a/doc/user_guide/introduction.rst
+++ b/doc/user_guide/introduction.rst
@@ -30,17 +30,17 @@ by the following figure:
   :alt: Illustration of hyperspectral datasets in different dimensionalities.
 
 To facilitate working with these datasets, HyperSpy distinguishes between
-:external+hyperspy:doc:`navigation and signal dimensions <navigation-signal-dimensions>`
+:external+hyperspy:ref:`navigation and signal dimensions <navigation-signal-dimensions>`
 that can be addressed separately and thus, for example, operations on a single
 spectrum can be easily mapped to a whole dataset.
 
 Notable features that **HyperSpy** provides are:
 
-- :external+hyperspy:doc:`base signal classes <user_guide/signal>`
+- :external+hyperspy:ref:`base signal classes <signal-label>`
   for the handling of (multidimensional) spectral data,
 - the necessary tools for loading :external+hyperspy:ref:`various data file formats
   <io>`,
-- :external+hyperspy:doc:`analytical tools <user_guide/signal1d>`
+- :external+hyperspy:ref:`analytical tools <signal1D-label>`
   that exploit the multidimensionality of datasets,
 - a user-friendly and powerful framework for :external+hyperspy:ref:`model fitting
   <model-label>` that
@@ -82,8 +82,8 @@ As an extension to HyperSpy, LumiSpy provides several signal types extending the
 :external+hyperspy:ref:`base classes available in HyperSpy
 <signal_subclasses_table-label>`. When the LumiSpy library is installed, these
 additional signal types are directly available to HyperSpy. To print all available
-specialised :external:py:class:`hyperspy.signal.BaseSignal` subclasses installed
-in your system call the :external:py:func:`hyperspy.utils.print_known_signal_types`
+specialised :external:class:`hyperspy.signal.BaseSignal` subclasses installed
+in your system call the :external:func:`hyperspy.api.print_known_signal_types`
 function:
 
 .. code-block:: python
@@ -100,40 +100,40 @@ signal types (or inheriting) signal types.
 
 .. table:: LumiSpy subclasses and their basic attributes.
 
-    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  BaseSignal subclass                                                    | signal_dimension |  signal_type  |  dtype  |  aliases                                                                  |
-    +=========================================================================+==================+===============+=========+===========================================================================+
-    |  :py:class:`~.signals.luminescence_spectrum.LumiSpectrum`               |        1         |  Luminescence |  real   | LumiSpectrum, LuminescenceSpectrum                                        |
-    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.cl_spectrum.CLSpectrum`                           |        1         |       CL      |  real   | CLSpectrum, cathodoluminescence                                           |
-    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.cl_spectrum.CLSEMSpectrum`                        |        1         |     CL_SEM    |  real   | CLSEM, cathodoluminescence SEM                                            |
-    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.cl_spectrum.CLSTEMSpectrum`                       |        1         |    CL_STEM    |  real   | CLSTEM, cathodoluminescence STEM                                          |
-    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.el_spectrum.ELSpectrum`                           |        1         |       EL      |  real   | ELSpectrum, electroluminescence                                           |
-    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.pl_spectrum.PLSpectrum`                           |        1         |       PL      |  real   | PLSpectrum, photoluminescence                                             |
-    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.luminescence_transient.LumiTransient`             |        1         |   Transient   |  real   | TRLumi, TR luminescence, time-resolved luminescence                       |
-    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
-    |  :py:class:`~.signals.luminescence_transientspec.LumiTransientSpectrum` |        2         | TransientSpec |  real   | TRLumiSpec, TR luminescence spectrum, time-resolved luminescence spectrum |
-    +-------------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    +----------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  BaseSignal subclass                                                 | signal_dimension |  signal_type  |  dtype  |  aliases                                                                  |
+    +======================================================================+==================+===============+=========+===========================================================================+
+    |  :class:`~.signals.luminescence_spectrum.LumiSpectrum`               |        1         |  Luminescence |  real   | LumiSpectrum, LuminescenceSpectrum                                        |
+    +----------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :class:`~.signals.cl_spectrum.CLSpectrum`                           |        1         |       CL      |  real   | CLSpectrum, cathodoluminescence                                           |
+    +----------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :class:`~.signals.cl_spectrum.CLSEMSpectrum`                        |        1         |     CL_SEM    |  real   | CLSEM, cathodoluminescence SEM                                            |
+    +----------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :class:`~.signals.cl_spectrum.CLSTEMSpectrum`                       |        1         |    CL_STEM    |  real   | CLSTEM, cathodoluminescence STEM                                          |
+    +----------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :class:`~.signals.el_spectrum.ELSpectrum`                           |        1         |       EL      |  real   | ELSpectrum, electroluminescence                                           |
+    +----------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :class:`~.signals.pl_spectrum.PLSpectrum`                           |        1         |       PL      |  real   | PLSpectrum, photoluminescence                                             |
+    +----------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :class:`~.signals.luminescence_transient.LumiTransient`             |        1         |   Transient   |  real   | TRLumi, TR luminescence, time-resolved luminescence                       |
+    +----------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
+    |  :class:`~.signals.luminescence_transientspec.LumiTransientSpectrum` |        2         | TransientSpec |  real   | TRLumiSpec, TR luminescence spectrum, time-resolved luminescence spectrum |
+    +----------------------------------------------------------------------+------------------+---------------+---------+---------------------------------------------------------------------------+
 
 The hierarchy of the LumiSpy signal types and their inheritance from HyperSpy
 is summarized in the following diagram:
 
-|   └── :external:py:class:`hyperspy.signal.BaseSignal`
-|       ├── :external:py:class:`hyperspy._signals.signal1d.Signal1D`
-|       │   └── :py:class:`~.signals.luminescence_spectrum.LumiSpectrum`
-|       │   │   ├── :py:class:`~.signals.cl_spectrum.CLSpectrum`
-|       │   │   │   ├── :py:class:`~.signals.cl_spectrum.CLSEMSpectrum` 
-|       │   │   │   └── :py:class:`~.signals.cl_spectrum.CLSTEMSpectrum` 
-|       │   │   ├── :py:class:`~.signals.el_spectrum.ELSpectrum`
-|       │   │   └── :py:class:`~.signals.pl_spectrum.PLSpectrum`
-|       │   └── :py:class:`~.signals.luminescence_transient.LumiTransient`
-|       └── :py:class:`hyperspy.signal.Signal2D`
-|           └── :py:class:`~.signals.luminescence_transientspec.LumiTransientSpectrum`
+|   └── :external:class:`hyperspy.signal.BaseSignal`
+|       ├── :external:class:`hyperspy._signals.signal1d.Signal1D`
+|       │   └── :class:`~.signals.luminescence_spectrum.LumiSpectrum`
+|       │   │   ├── :class:`~.signals.cl_spectrum.CLSpectrum`
+|       │   │   │   ├── :class:`~.signals.cl_spectrum.CLSEMSpectrum` 
+|       │   │   │   └── :class:`~.signals.cl_spectrum.CLSTEMSpectrum` 
+|       │   │   ├── :class:`~.signals.el_spectrum.ELSpectrum`
+|       │   │   └── :class:`~.signals.pl_spectrum.PLSpectrum`
+|       │   └── :class:`~.signals.luminescence_transient.LumiTransient`
+|       └── :class:`hyperspy.signal.Signal2D`
+|           └── :class:`~.signals.luminescence_transientspec.LumiTransientSpectrum`
 |
 |
 
@@ -147,7 +147,7 @@ but also bug reports and feature requests from any users. Don't hesitate
 to join the discussions!
 
 Currrently, we have implemented the base functionality that extends 
-:external+hyperspy:ref:`HyperSpy's capabilities <user_guide-label>`
+:external+hyperspy:ref:`HyperSpy's capabilities <user_guide>`
 to additional signal classes. In the near future, the following functions
 should be developed:
 

--- a/doc/user_guide/introduction.rst
+++ b/doc/user_guide/introduction.rst
@@ -38,13 +38,15 @@ Notable features that **HyperSpy** provides are:
 
 - :external+hyperspy:ref:`base signal classes <signal-label>`
   for the handling of (multidimensional) spectral data,
-- the necessary tools for loading :external+hyperspy:ref:`various data file formats
-  <io>`,
+- the necessary tools for  :external+hyperspy:ref:`loading <io>`
+  :external+rsciio:ref:`various data file formats <supported-formats>` using the
+  library `RosettaSciIO <https://hyperspy.org/rosettasciio>`_,
 - :external+hyperspy:ref:`analytical tools <signal1D-label>`
   that exploit the multidimensionality of datasets,
 - a user-friendly and powerful framework for :external+hyperspy:ref:`model fitting
-  <model-label>` that
-  provides many standard functions and can be easily extended to custom ones,
+  <model-label>` that provides many :external+hyperspy:ref:`standard functions
+  <model_components-label>` and can be easily extended to
+  :external+hyperspy:ref:`custom ones <expression_component-label>`,
 - :external+hyperspy:ref:`machine learning <ml-label>`
   algorithms that can be useful, e.g. for denoising data,
 - efficient handling of :external+hyperspy:ref:`big datasets <big-data-label>`,
@@ -55,7 +57,7 @@ Notable features that **HyperSpy** provides are:
   :external+hyperspy:ref:`regions of interest <roi-label>` and a powerful
   numpy-style :external+hyperspy:ref:`indexing mechanism <signal.indexing>`,
 - handling of :external+hyperspy:ref:`non-uniform data axes <Axes_types>`
-  (introduced in the :external+hyperspy:ref:`v1.7 release 
+  (introduced in the :external+hyperspy:ref:`1.7.0 release 
   <changes_1.7.0>`).
 
 **LumiSpy** provides in particular:
@@ -124,16 +126,16 @@ The hierarchy of the LumiSpy signal types and their inheritance from HyperSpy
 is summarized in the following diagram:
 
 |   └── :external:class:`hyperspy.signal.BaseSignal`
-|       ├── :external:class:`hyperspy._signals.signal1d.Signal1D`
-|       │   └── :class:`~.signals.luminescence_spectrum.LumiSpectrum`
-|       │   │   ├── :class:`~.signals.cl_spectrum.CLSpectrum`
-|       │   │   │   ├── :class:`~.signals.cl_spectrum.CLSEMSpectrum` 
-|       │   │   │   └── :class:`~.signals.cl_spectrum.CLSTEMSpectrum` 
-|       │   │   ├── :class:`~.signals.el_spectrum.ELSpectrum`
-|       │   │   └── :class:`~.signals.pl_spectrum.PLSpectrum`
-|       │   └── :class:`~.signals.luminescence_transient.LumiTransient`
-|       └── :class:`hyperspy.signal.Signal2D`
-|           └── :class:`~.signals.luminescence_transientspec.LumiTransientSpectrum`
+|           ├── :external:class:`hyperspy._signals.signal1d.Signal1D`
+|           │       └── :class:`~.signals.luminescence_spectrum.LumiSpectrum`
+|           │       │       ├── :class:`~.signals.cl_spectrum.CLSpectrum`
+|           │       │       │       ├── :class:`~.signals.cl_spectrum.CLSEMSpectrum` 
+|           │       │       │       └── :class:`~.signals.cl_spectrum.CLSTEMSpectrum` 
+|           │       │       ├── :class:`~.signals.el_spectrum.ELSpectsrum`
+|           │       │       └── :class:`~.signals.pl_spectrum.PLSpectrum`
+|           │       └── :class:`~.signals.luminescence_transient.LumiTransient`
+|           └── :class:`hyperspy.signal.Signal2D`
+|                   └── :class:`~.signals.luminescence_transientspec.LumiTransientSpectrum`
 |
 |
 
@@ -142,8 +144,8 @@ Where are we heading?
 =====================
 
 LumiSpy is under active development, and as a user-driven project, we welcome
-contributions (see :ref:`contributing_label`) to the code and documentation,
-but also bug reports and feature requests from any users. Don't hesitate
+:ref:`contributions <contributing_label>` to the code and documentation,
+but also bug reports and feature requests from any user. Don't hesitate
 to join the discussions!
 
 Currrently, we have implemented the base functionality that extends 
@@ -151,7 +153,8 @@ Currrently, we have implemented the base functionality that extends
 to additional signal classes. In the near future, the following functions
 should be developed:
 
-- handling of transient (time-resolved) data,
-- reading of common PL data formats (see :external+rsciio:ref:`supported-formats` of RosettaSciIO),
+- handling of transient (time-resolved) data with dedicated models,
+- extend the capabilities for reading relevant data formats
+  (see :external+rsciio:ref:`supported-formats` of RosettaSciIO),
 - more dedicated analysis functionalities,
 - ...

--- a/doc/user_guide/introduction.rst
+++ b/doc/user_guide/introduction.rst
@@ -30,12 +30,9 @@ by the following figure:
   :alt: Illustration of hyperspectral datasets in different dimensionalities.
 
 To facilitate working with these datasets, HyperSpy distinguishes between
-`navigation and signal dimensions <https://hyperspy.org/hyperspy-doc/current/user_guide/getting_started.html#the-navigation-and-signal-dimensions>`_
+:external+hyperspy:doc:`navigation and signal dimensions <navigation-signal-dimensions>`
 that can be addressed separately and thus, for example, operations on a single
 spectrum can be easily mapped to a whole dataset.
-
-..
-    Eith HyperSpy 2.0 update link above to :external+hyperspy:doc:`navigation and signal dimensions <navigation-signal-dimensions>`
 
 Notable features that **HyperSpy** provides are:
 

--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -93,14 +93,12 @@ while parallel acquisition with a CCD is characterized by the
 General
 =======
 
-See `HyperSpy-Metadata-General
-<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#general>`_.
+See :external+hyperspy:doc:`HyperSpy-Metadata-General <general-metadata>`
 
 Sample
 ======
 
-See `HyperSpy-Metadata-Sample
-<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#sample>`_.
+See :external+hyperspy:doc:`HyperSpy-Metadata-Sample <sample-metadata>`.
 
 Signal
 ======
@@ -117,8 +115,7 @@ quantity
     The name of the quantity of the “intensity axis” with the units in round brackets if
     required, for example 'Intensity (counts/s)'.
 
-See `HyperSpy-Metadata-Signal
-<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#sample>`__
+See :external+hyperspy:doc:`HyperSpy-Metadata-Signal <signal-metadata>`
 for additional fields.
 
 Acquisition Instrument
@@ -127,10 +124,8 @@ Acquisition Instrument
 Laser / SEM / TEM
 =================
 
-For **SEM** or **TEM** see `HyperSpy-Metadata-SEM
-<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#sem>`_
-or `HyperSpy-Metadata-TEM
-<https://hyperspy.org/hyperspy-doc/current/user_guide/metadata_structure.html#tem>`_.
+For **SEM** or **TEM** see :external+exspy:doc:`ExSpy-Metadata-SEM/TEM
+<source-metadata>`.
 
 
 Laser

--- a/doc/user_guide/metadata_structure.rst
+++ b/doc/user_guide/metadata_structure.rst
@@ -6,7 +6,7 @@ LumiSpy metadata structure
 LumiSpy extends the :external+hyperspy:ref:`HyperSpy metadata structure
 <metadata_structure>`
 with conventions for metadata specific to its signal types. Refer to the
-:external+hyperspy:doc:`HyperSpy metadata documentation <user_guide/metadata_structure>`
+:external+hyperspy:ref:`HyperSpy metadata documentation <metadata_structure>`
 for general metadata fields.
 
 The metadata of any **signal objects** is stored in the `metadata` attribute,
@@ -17,9 +17,9 @@ label followed by the ``_units`` suffix.
 
 Besides directly accessing the metadata tree structure, e.g.
 ``s.metadata.Signal.signal_type``, the HyperSpy methods
-:external:py:meth:`set_item() <hyperspy.misc.utils.DictionaryTreeBrowser.set_item>`,
-:external:py:meth:`has_item() <hyperspy.misc.utils.DictionaryTreeBrowser.has_item>` and
-:external:py:meth:`get_item() <hyperspy.misc.utils.DictionaryTreeBrowser.get_item>`
+:external:meth:`set_item() <hyperspy.misc.utils.DictionaryTreeBrowser.set_item>`,
+:external:meth:`has_item() <hyperspy.misc.utils.DictionaryTreeBrowser.has_item>` and
+:external:meth:`get_item() <hyperspy.misc.utils.DictionaryTreeBrowser.get_item>`
 can be used to add to, search for and read from items in the metadata tree,
 respectively.
 
@@ -93,12 +93,12 @@ while parallel acquisition with a CCD is characterized by the
 General
 =======
 
-See :external+hyperspy:doc:`HyperSpy-Metadata-General <general-metadata>`
+See :external+hyperspy:ref:`HyperSpy-Metadata-General <general-metadata>`
 
 Sample
 ======
 
-See :external+hyperspy:doc:`HyperSpy-Metadata-Sample <sample-metadata>`.
+See :external+hyperspy:ref:`HyperSpy-Metadata-Sample <sample-metadata>`.
 
 Signal
 ======
@@ -115,7 +115,7 @@ quantity
     The name of the quantity of the “intensity axis” with the units in round brackets if
     required, for example 'Intensity (counts/s)'.
 
-See :external+hyperspy:doc:`HyperSpy-Metadata-Signal <signal-metadata>`
+See :external+hyperspy:ref:`HyperSpy-Metadata-Signal <signal-metadata>`
 for additional fields.
 
 Acquisition Instrument
@@ -124,7 +124,7 @@ Acquisition Instrument
 Laser / SEM / TEM
 =================
 
-For **SEM** or **TEM** see :external+exspy:doc:`ExSpy-Metadata-SEM/TEM
+For **SEM** or **TEM** see :external+exspy:ref:`ExSpy-Metadata-SEM/TEM
 <source-metadata>`.
 
 

--- a/doc/user_guide/signal_axis.rst
+++ b/doc/user_guide/signal_axis.rst
@@ -3,8 +3,7 @@
 Non-uniform signal axes
 ***********************
 
-LumiSpy facilitates the use of `non-uniform axes 
-<https://hyperspy.org/hyperspy-doc/current/user_guide/axes.html#non-uniform-data-axis>`_,
+LumiSpy facilitates the use of :external+hyperspy:ref:`non-uniform axes <data-axis>`,
 where the points of the axis vector are not uniformly spaced. This situation
 occurs in particular when converting a wavelength scale to energy (eV) or
 wavenumbers (e.g. for Raman shifts).
@@ -128,9 +127,8 @@ it is converted into a :external:py:class:`hyperspy.signal.BaseSignal` object
 before the transformation.
 
 See :ref:`fitting_variance` for more general information on data variance
-in the context of model fitting and the HyperSpy documentation on `setting
-the noise properties
-<https://hyperspy.org/hyperspy-doc/current/user_guide/signal.html?highlight=variance_linear_model#setting-the-noise-properties>`_.
+in the context of model fitting and the HyperSpy documentation on `
+:external+hyperspy:ref:`setting the noise properties <signal.noise_properties>`.
 
 .. Note::
 

--- a/doc/user_guide/signal_axis.rst
+++ b/doc/user_guide/signal_axis.rst
@@ -9,10 +9,10 @@ occurs in particular when converting a wavelength scale to energy (eV) or
 wavenumbers (e.g. for Raman shifts).
 
 The conversion of the signal axis can be performed using the functions 
-:py:meth:`~.signals.luminescence_spectrum.LumiSpectrum.to_eV`,
-:py:meth:`~.signals.luminescence_spectrum.LumiSpectrum.to_invcm` and
-:py:meth:`~.signals.luminescence_spectrum.LumiSpectrum.to_raman_shift`
-(alias for :py:meth:`~.signals.luminescence_spectrum.LumiSpectrum.to_invcm_relative`).
+:meth:`~.signals.luminescence_spectrum.LumiSpectrum.to_eV`,
+:meth:`~.signals.luminescence_spectrum.LumiSpectrum.to_invcm` and
+:meth:`~.signals.luminescence_spectrum.LumiSpectrum.to_raman_shift`
+(alias for :meth:`~.signals.luminescence_spectrum.LumiSpectrum.to_invcm_relative`).
 If the unit of the signal axis is set, the functions can handle wavelengths in
 either nm or µm.
 
@@ -123,7 +123,7 @@ renormalization is automatically performed by LumiSpy if ``jacobian=True``.
 In particular, homoscedastic (constant) noise will consequently become
 heteroscedastic (changing as a function of the signal axis vector). Therefore,
 if the ``metadata.Signal.Noise_properties.variance`` attribute is a constant,
-it is converted into a :external:py:class:`hyperspy.signal.BaseSignal` object
+it is converted into a :external:class:`hyperspy.api.signals.BaseSignal` object
 before the transformation.
 
 See :ref:`fitting_variance` for more general information on data variance
@@ -136,6 +136,6 @@ in the context of model fitting and the HyperSpy documentation on `
     ``metadata.Signal.Noise_properties.Variance_linear_model`` are reset to
     their default values (``gain_factor=1``, ``gain_offset=0`` and ``correlation_factor=1``).
     Should these values deviate from the defaults, make sure to run
-    :external:py:meth:`hyperspy.signal.BaseSignal.estimate_poissonian_noise_variance`
+    :external:meth:`hyperspy.api.signals.BaseSignal.estimate_poissonian_noise_variance`
     prior to the transformation.
 

--- a/doc/user_guide/signal_axis.rst
+++ b/doc/user_guide/signal_axis.rst
@@ -87,8 +87,8 @@ Jacobian transformation
 When transforming the signal axis, the signal intensity is automatically
 rescaled (Jacobian transformation), unless the ``jacobian=False`` option is
 given. Only converting the signal axis, and leaving the signal intensity
-unchanged, implies that the integral of the signal over the same interval would
-lead to different results depending on the quantity on the axis (see e.g.
+unchanged, would implie that the integral of the signal over the same interval
+leads to different results depending on the quantity on the axis (see e.g.
 [Mooney]_ and [Wang]_).
 
 For the energy axis as example, if we require :math:`I(E)dE = I(\lambda)d\lambda`,
@@ -126,7 +126,7 @@ if the ``metadata.Signal.Noise_properties.variance`` attribute is a constant,
 it is converted into a :external:class:`hyperspy.api.signals.BaseSignal` object
 before the transformation.
 
-See :ref:`fitting_variance` for more general information on data variance
+See the section on :ref:`fitting_variance` for more general information on data variance
 in the context of model fitting and the HyperSpy documentation on `
 :external+hyperspy:ref:`setting the noise properties <signal.noise_properties>`.
 

--- a/doc/user_guide/signal_tools.rst
+++ b/doc/user_guide/signal_tools.rst
@@ -108,7 +108,7 @@ finding the position of the maximum intensity of a peak, useful in particular fo
 non-symmetric peaks with pronounced shoulders.
 It finds the centroid (center of mass) of a peak in the spectrum from the signal axis
 units (or pixel number) and the intensity at each pixel value. It basically represents a
-"weighted average" of the peak as such:
+"weighted average" of the peak defined as:
 
 .. math::
 
@@ -144,7 +144,7 @@ with the `kwargs` of :external:class:`scipy.interpolate.interp1d` function.
 
     This function only works for a single peak. If you have multiple peaks,
     slice the signal beforehand or use the slice parameter (which follows the
-    ``s.isig[:]`` convention).
+    ``s.isig[:]`` convention).s
 
 .. Note::
 
@@ -197,7 +197,7 @@ The default operational mode is ``inplace=False`` (a new signal object is return
 
 .. code-block:: python
 
-    >>> s.remove_negative(0.1)
+    >>> s2 = s.remove_negative(0.1)
 
 
 .. _crop_edges:

--- a/doc/user_guide/signal_tools.rst
+++ b/doc/user_guide/signal_tools.rst
@@ -16,8 +16,8 @@ Scaling and normalizing signal data
 For comparative plotting or a detailed analysis, the intensity of spectra may
 need to be either scaled by the respective integration times or
 normalized. The luminescence signal classes provide these functionalities in the
-methods :py:meth:`~.signals.common_luminescence.CommonLumi.scale_by_exposure` and 
-:py:meth:`~.signals.common_luminescence.CommonLumi.normalize`.
+methods :meth:`~.signals.common_luminescence.CommonLumi.scale_by_exposure` and 
+:meth:`~.signals.common_luminescence.CommonLumi.normalize`.
 
 Both functions can operate directly on the signal (``inplace=True``), but as default
 a new signal is returned.
@@ -53,14 +53,14 @@ Peak identification
 HyperSpy provides functions to find the positions of maxima or minima in a
 dataset:
 
-- :external+hyperspy:meth:`indexmax() <hyperspy.signal.BaseSignal.indexmax>` - 
+- :external:meth:`indexmax() <hyperspy.api.signals.BaseSignal.indexmax>` - 
   return the index of the maximum value along a given axis.
-- :external+hyperspy:meth:`indexmin() <hyperspy.signal.BaseSignal.indexmin>` - 
+- :external:meth:`indexmin() <hyperspy.api.signals.BaseSignal.indexmin>` - 
   return the index of the minimum value along a given axis.
-- :external+hyperspy:meth:`valuemax() <hyperspy.signal.BaseSignal.valuemax>` - 
+- :external:meth:`valuemax() <hyperspy.api.signals.BaseSignal.valuemax>` - 
   return the position/coordinates of the maximum value along a given axis in
   calibrated units.
-- :external+hyperspy:meth:`valuemin() <hyperspy.signal.BaseSignal.valuemin>` - 
+- :external:meth:`valuemin() <hyperspy.api.signals.BaseSignal.valuemin>` - 
   return the position/coordinates of the minimum value along a given axis in
   calibrated units.
 
@@ -69,7 +69,7 @@ the operation and return a new signal containing the result.
 
 A much more powerful method to identify peaks is using the **peak finding routine**
 based on the downward zero-crossings of the first derivative of a signal:
-:external+hyperspy:meth:`find_peaks1D_ohaver() <hyperspy._signals.signal1d.Signal1D.find_peaks1D_ohaver>`.
+:external:meth:`find_peaks1D_ohaver() <hyperspy.api.signals.Signal1D.find_peaks1D_ohaver>`.
 This function can find multiple peaks in a dataset and has a number of parameters
 for fine-tuning the sensitivity, etc.
 
@@ -87,7 +87,7 @@ Peak Width
 
 For asymmetric peaks, :ref:`fitted functions <fitting_luminescence>` may not provide
 an accurate description of the peak, in particular the peak width. The function
-:external+hyperspy:meth:`estimate_peak_width() <hyperspy._signals.signal1d.Signal1D.estimate_peak_width>`
+:external:meth:`estimate_peak_width() <hyperspy.api.signals.Signal1D.estimate_peak_width>`
 determines the **width of a peak** at a certain fraction of its maximum value. The
 default value ``factor=0.5`` returns the full width at half maximum (FWHM).
 
@@ -102,8 +102,8 @@ default value ``factor=0.5`` returns the full width at half maximum (FWHM).
 Calculating the centroid of a spectrum (centre of mass)
 -------------------------------------------------------
 
-The function :py:meth:`~.signals.luminescence_spectrum.LumiSpectrum.centroid`
-(based on the utility function :py:func:`~.utils.signals.com`) is an alternative to
+The function :meth:`~.signals.luminescence_spectrum.LumiSpectrum.centroid`
+(based on the utility function :func:`~.utils.signals.com`) is an alternative to
 finding the position of the maximum intensity of a peak, useful in particular for
 non-symmetric peaks with pronounced shoulders.
 It finds the centroid (center of mass) of a peak in the spectrum from the signal axis
@@ -118,11 +118,11 @@ where :math:`x_i` is the wavelength (or pixel number) at which the
 intensity of the spectrum :math:`I_i` is measured.
 
 This function also works for non-linear axes. For the
-:external:py:class:`hyperspy.axes.FunctionalDataAxis`, the centroid is extrapolated
+:external:class:`hyperspy.axes.FunctionalDataAxis`, the centroid is extrapolated
 based on the function used to create the non-uniform axis. For
-:external:py:class:`hyperspy.axes.DataAxis`, a linear interpolation between the
+:external:class:`hyperspy.axes.DataAxis`, a linear interpolation between the
 axes points at the center of mass is assumed, but this behaviour can be changed
-with the `kwargs` of :external:py:class:`scipy.interpolate.interp1d` function.
+with the `kwargs` of :external:class:`scipy.interpolate.interp1d` function.
 
 .. code-block:: python
 
@@ -159,22 +159,22 @@ Signal statistics and analytical operations
 
 **Standard statistical operations** can be performed on the data or a subset of the
 data, notably these include 
-:external+hyperspy:meth:`max() <hyperspy.signal.BaseSignal.max>`,
-:external+hyperspy:meth:`min() <hyperspy.signal.BaseSignal.min>`,
-:external+hyperspy:meth:`sum() <hyperspy.signal.BaseSignal.sum>`,
-:external+hyperspy:meth:`mean() <hyperspy.signal.BaseSignal.mean>`,
-:external+hyperspy:meth:`std() <hyperspy.signal.BaseSignal.std>`, and
-:external+hyperspy:meth:`var() <hyperspy.signal.BaseSignal.var>`. Variations of
+:external:meth:`max() <hyperspy.api.signals.BaseSignal.max>`,
+:external:meth:`min() <hyperspy.api.signals.BaseSignal.min>`,
+:external:meth:`sum() <hyperspy.api.signals.BaseSignal.sum>`,
+:external:meth:`mean() <hyperspy.api.signals.BaseSignal.mean>`,
+:external:meth:`std() <hyperspy.api.signals.BaseSignal.std>`, and
+:external:meth:`var() <hyperspy.api.signals.BaseSignal.var>`. Variations of
 all these functions exist that ignore missing values (NaN) if present, e.g.
-:external+hyperspy:meth:`nanmax() <hyperspy.signal.BaseSignal.nanmax>`.
+:external:meth:`nanmax() <hyperspy.api.signals.BaseSignal.nanmax>`.
 
 **Integration** along a specified signal axis is performed using the function 
-:external+hyperspy:meth:`integrate1D() <hyperspy.signal.BaseSignal.integrate1D()>`.
+:external:meth:`integrate1D() <hyperspy.api.signals.BaseSignal.integrate1D()>`.
 
 The numerical **derivative** of a signal can be calculated using the function
-:external+hyperspy:meth:`derivative() <hyperspy.signal.BaseSignal.derivative()>`,
+:external:meth:`derivative() <hyperspy.api.signals.BaseSignal.derivative()>`,
 while the *n*-th order **discrete difference** can be calculated using
-:external+hyperspy:meth:`diff() <hyperspy.signal.BaseSignal.diff()>`.
+:external:meth:`diff() <hyperspy.api.signals.BaseSignal.diff()>`.
 
 These functions take the ``axis`` keyword to define along which axis to perform
 the operation and return a new signal containing the result:
@@ -191,7 +191,7 @@ Replacing negative data values
 
 Log-scale plotting fails in the presence of negative values in the dataset 
 (e.g. introduced after background removal). In this case, the utility function
-:py:meth:`~.signals.common_luminescence.CommonLumi.remove_negative` replaces
+:meth:`~.signals.common_luminescence.CommonLumi.remove_negative` replaces
 all negative values in the data array by a ``basevalue`` (default ``basevalue=1``).
 The default operational mode is ``inplace=False`` (a new signal object is returned).
 
@@ -205,7 +205,7 @@ The default operational mode is ``inplace=False`` (a new signal object is return
 Crop edges
 ==========
 
-The function :py:meth:`~.signals.common_luminescence.CommonLumi.crop_edges`
+The function :meth:`~.signals.common_luminescence.CommonLumi.crop_edges`
 removes the specified number of pixels from all four edges of a spectral map.
 It is a convenience wrapper for the ``inav`` :external+hyperspy:ref:`method in
 HyperSpy <signal.indexing>`.

--- a/doc/user_guide/utilities.rst
+++ b/doc/user_guide/utilities.rst
@@ -12,10 +12,10 @@ Join spectra
 
 In case several spectra (or spectral images) where subsequently recorded for
 different, but overlapping spectral windows, LumiSpy provides a utility
-:py:func:`~.utils.axes.join_spectra` to merge these into a single spectrum. The 
+:func:`~.utils.axes.join_spectra` to merge these into a single spectrum. The 
 main argument is a list of two or more spectral objects. Spectra are joined at
 the centre of the overlapping range along the signal axis. To avoid steps in the
-intensity, several parameters (see docstring: :py:func:`~.utils.axes.join_spectra`)
+intensity, several parameters (see docstring: :func:`~.utils.axes.join_spectra`)
 allow to tune the scaling of the later signals with respect to the previous ones.
 By default, the scaling parameter is determined as average ratio between the two
 signals in the range of +/- 50 pixels around the centre of the overlapping region.
@@ -31,7 +31,7 @@ signals in the range of +/- 50 pixels around the centre of the overlapping regio
 Exporting text files
 ====================
 
-LumiSpy includes a function :py:meth:`~.signals.luminescence_spectrum.LumiSpectrum.savetxt`
+LumiSpy includes a function :meth:`~.signals.luminescence_spectrum.LumiSpectrum.savetxt`
 that exports the data of a signal object
 (with not more than two axes) to a simple `.txt` (or `.csv`) file. Can facilitate
 data transfer to other programs, but no metadata is included. By default,
@@ -77,10 +77,10 @@ Unit conversion
 For convenience, LumiSpy provides functions that convert between different
 units commonly used for the signal axis. Namely,
 
-- :py:func:`~.utils.axes.nm2eV`
-- :py:func:`~.utils.axes.eV2nm`
-- :py:func:`~.utils.axes.nm2invcm`
-- :py:func:`~.utils.axes.invcm2nm`
+- :func:`~.utils.axes.nm2eV`
+- :func:`~.utils.axes.eV2nm`
+- :func:`~.utils.axes.nm2invcm`
+- :func:`~.utils.axes.invcm2nm`
 
 For the energy axis, the conversion uses the wavelength-dependent refractive
 index of air.
@@ -91,7 +91,7 @@ index of air.
 Solving the grating equation
 ----------------------------
 
-The function :py:func:`~.utils.axes.solve_grating_equation` (relationship between
+The function :func:`~.utils.axes.solve_grating_equation` (relationship between
 wavelength and pixel position in the detector plane) follows the conventions
 described in the tutorial from  `Horiba Scientific
 <https://horiba.com/uk/scientific/products/optics-tutorial/wavelength-pixel-position>`_.

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         "build-doc": [
             "sphinx>=4.3.0",
             "sphinx_rtd_theme>=0.5.1",
-            "sphinx-toggleprompt",
+            "sphinx-copybutton",
         ],
     },
     package_data={


### PR DESCRIPTION
- Add intersphinx links after HyperSpy2.0/ExSpy0.1 release (Closes #174).
- Add workflow to test doc build including links and correct links
- Adapt documentation based on HyperSpy2.0 release

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] ready for review.
