### PR TITLE
Fix failing documentation builds

### DIFF
--- a/doc/citing.rst
+++ b/doc/citing.rst
@@ -11,7 +11,7 @@ and attention. Citations help us justify the effort that goes into
 building and maintaining this project.
 
 The DOI in the badge below is the `Concept DOI
-<https://help.zenodo.org/faq/#versioning>`_ --
+<https://support.zenodo.org/help/en-gb/1-upload-deposit/97-what-is-doi-versioning>`_ --
 it can be used to cite the project without referring to a specific
 version. If you are citing LumiSpy because you have used it to process data,
 please use the DOI of the specific version that you have employed. You can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,8 +79,9 @@ doc = [
   "sphinx>=4.3.0",
   "sphinx_rtd_theme>=0.5.1",
   "sphinx-copybutton",
-  "sphinxcontrib-towncrier",
-  "towncrier",
+  "sphinxcontrib-towncrier>=0.3.0a0",
+  # unpin when sphinxcontrib-towncrier support more recent version to towncrier
+  "towncrier<24",
 ]
 dev = [
   "black",
@@ -137,8 +138,8 @@ fallback_version = "0.3.dev0"
 directory = "upcoming_changes/"
 filename = "CHANGELOG.rst"
 issue_format = "`#{issue} <https://github.com/lumispy/lumispy/issues/{issue}>`_"
+package = "lumispy"
 title_format = "{version} ({project_date})"
-package_dir = "lumispy"
 type = [
     { directory = "new", name = "New features", showcontent = true },
     { directory = "enhancements", name = "Enhancements", showcontent = true },


### PR DESCRIPTION
- Fix towncrier in `pyproject.toml` (See also https://github.com/hyperspy/hyperspy/pull/3400#issuecomment-2262444304 )
- Update Zenodo DOI versioning link