### PR TITLE
Convert either of the TransientSpec signal axes to navigation axes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,4 +57,4 @@ jobs:
         uses: actions/checkout@v4
       - name: Create Release
         if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository_owner == 'lumispy' }}
-        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,4 +65,4 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: ${{ always() }} && ${{ matrix.PYTEST_ARGS_COVERAGE }} 
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,6 +48,7 @@ intersphinx_mapping = {
 intersphinx_disabled_domains = ["std"]
 
 linkcheck_ignore = [
+    "https://doi.org/10.1063/5.0080486",  # 403 Client Error: Forbidden for url
     "https://doi.org/10.1021/jz401508t",  # 403 Client Error: Forbidden for url
     "https://github.com/LumiSpy/lumispy/security/code-scanning",  # 404 Client Error: Not Found for url (even though page exists)
 ]

--- a/doc/user_guide/streak_images.rst
+++ b/doc/user_guide/streak_images.rst
@@ -78,7 +78,7 @@ class provides the functions :meth:`~.signals.luminescence_transientspec.LumiTra
 and :meth:`~.signals.luminescence_transientspec.LumiTransientSpectrum.time2nav`
 to convert streak images to the :class:`~.signals.luminescence_transient.LumiTransient`
 and :class:`~.signals.luminescence_spectrum.LumiSpectrum` classes, respectively.
-Both functions return a new signal. By default, the methods ensure that the data
+Both functions return a new signal. By default (``optimize=True``), the methods ensure that the data
 is stored optimally, hence often making a copy of the data.
 
 .. code-block:: python

--- a/doc/user_guide/streak_images.rst
+++ b/doc/user_guide/streak_images.rst
@@ -39,15 +39,14 @@ streak image by:
     >>> import numpy as np
     ...
     >>> data = np.arange(10*20).reshape(10, 20)
+    >>> ax0 = {"name": "Time", "units": "ps", "size": 10}
+    >>> ax1 = {"name": "Wavelength", "units": "nm", "size": 20}
+    >>> s = lum.signals.LumiTransientSpectrum(data, axes = [ax0, ax1])
     ...
-    >>> s = lum.signals.LumiTransientSpectrum(data)
-    >>> s.axes_manager[-1].name = "Time"
-    >>> s.axes_manager[-1].units = "ns"
-    >>> s.axes_manager[-2].name = "Wavelength"
-    >>> s.axes_manager[-2].units = "nm"
     >>> s.sum(axis='Time')
     >>> # Or alternatively:
     >>> s.sum(axis=-1)
+    <LumiSpectrum, title: , dimensions: (|20)>
 
 Similarly, the transient summed over all wavelengths is obtained by:
 
@@ -56,6 +55,10 @@ Similarly, the transient summed over all wavelengths is obtained by:
     >>> s.sum(axis='Wavelength')
     >>> # Or alternatively:
     >>> s.sum(axis=-2)
+    <LumiTransient, title: , dimensions: (|10)>
+
+The following image shows the plot of a streak camera image and its one-dimensional
+representations obtained by summing over either the wavelength or time dimensions:
 
 .. image:: images/streakmap.svg
   :width: 700
@@ -66,3 +69,49 @@ Similarly, the transient summed over all wavelengths is obtained by:
 Iteration over the spectral or time dimension
 =============================================
 
+When performing an analysis where the same methods (e.g. a model fit) should be applied
+at every spectral position or at every time, it is convenient and more efficient
+to iterate over the corresponding axis. Therefore, this axis should be converted
+from a ``signal`` to a ``navigation`` dimension. To this end, the 
+:class:`~.signals.luminescence_transientspec.LumiTransientSpectrum`
+class provides the functions :meth:`~.signals.luminescence_transientspec.LumiTransientSpectrum.spec2nav`
+and :meth:`~.signals.luminescence_transientspec.LumiTransientSpectrum.time2nav`
+to convert streak images to the :class:`~.signals.luminescence_transient.LumiTransient`
+and :class:`~.signals.luminescence_spectrum.LumiSpectrum` classes, respectively.
+Both functions return a new signal. By default, the methods ensure that the data
+is stored optimally, hence often making a copy of the data.
+
+.. code-block:: python
+
+    >>> import lumispy as lum
+    >>> import numpy as np
+    ...
+    >>> data = np.ones(100).reshape(10, 10)
+    >>> ax0 = {"name": "Time", "units": "ps", "size": 10}
+    >>> ax1 = {"name": "Wavelength", "units": "nm", "size": 10}
+    >>> s = lum.signals.LumiTransientSpectrum(data, axes = [ax0, ax1])
+    ...
+    >>> s
+    <LumiTransientSpectrum, title: , dimensions: (|10, 10)>
+    >>> s.spec2nav()
+    <LumiTransient, title: , dimensions: (10|10)>
+    >>> s.time2nav()
+    <LumiSpectrum, title: , dimensions: (10|10)>
+
+.. Note::
+
+    In case of existing navigation axes (e.g. linescan or map of streak images),
+    the new axis is added as first axis:
+    
+    .. code-block:: python
+    
+        >>> data = np.ones(1000).reshape(10, 10, 10)
+        >>> ax0 = {"name": "Position", "units": "px", "size": 10}
+        >>> ax1 = {"name": "Time", "units": "ps", "size": 10}
+        >>> ax2 = {"name": "Wavelength", "units": "nm", "size": 10}
+        >>> s = lum.signals.LumiTransientSpectrum(data, axes= [ax0, ax1, ax2])
+        ...
+        >>> s.axes_manager[0]
+        <Position axis, size: 10, index: 0>
+        >>> s.time2nav().axes_manager[0]
+        <Time axis, size: 10, index: 0>

--- a/doc/user_guide/streak_images.rst
+++ b/doc/user_guide/streak_images.rst
@@ -61,3 +61,8 @@ Similarly, the transient summed over all wavelengths is obtained by:
   :width: 700
   :alt: Plot of a streak camera image and its one-dimensional representations
         obtained by summing over either the wavelength or time dimensions.
+
+
+Iteration over the spectral or time dimension
+=============================================
+

--- a/lumispy/hyperspy_extension.yaml
+++ b/lumispy/hyperspy_extension.yaml
@@ -21,6 +21,7 @@ signals:
     signal_type: Luminescence
     signal_type_aliases:
       - LuminescenceSpectrum
+      - LumiSpectrum
     signal_dimension: 1
     dtype: real
     lazy: False
@@ -29,6 +30,7 @@ signals:
     signal_type: Luminescence
     signal_type_aliases:
       - LuminescenceSpectrum
+      - LumiSpectrum
     signal_dimension: 1
     dtype: real
     lazy: True
@@ -132,9 +134,9 @@ signals:
   LumiTransient:
     signal_type: Transient
     signal_type_aliases:
+      - LumiTransient
       - TRLumi
       - TR luminescence
-      - time-resolved luminescence
     signal_dimension: 1
     dtype: real
     lazy: False
@@ -142,9 +144,9 @@ signals:
   LazyLumiTransient:
     signal_type: Transient
     signal_type_aliases:
+      - LumiTransient
       - TRLumi
       - TR luminescence
-      - time-resolved luminescence
     signal_dimension: 1
     dtype: real
     lazy: True
@@ -153,10 +155,10 @@ signals:
   TransientSpectrumCasting: # allows casting to either Luminescence or Transient when dimensionality is reduced
     signal_type: TransientSpectrum
     signal_type_aliases:
+      - LumiTransientSpectrum
       - TransientSpec
       - TRLumiSpec
       - TR luminescence spectrum
-      - time-resolved luminescence spectrum
     signal_dimension: 1
     dtype: real
     lazy: False
@@ -165,10 +167,10 @@ signals:
   LumiTransientSpectrum:
     signal_type: TransientSpectrum
     signal_type_aliases:
+      - LumiTransientSpectrum
       - TransientSpec
       - TRLumiSpec
       - TR luminescence spectrum
-      - time-resolved luminescence spectrum
     signal_dimension: 2
     dtype: real
     lazy: False
@@ -176,10 +178,10 @@ signals:
   LazyLumiTransientSpectrum:
     signal_type: TransientSpectrum
     signal_type_aliases:
+      - LumiTransientSpectrum
       - TransientSpec
       - TRLumiSpec
       - TR luminescence spectrum
-      - time-resolved luminescence spectrum
     signal_dimension: 2
     dtype: real
     lazy: True

--- a/lumispy/signals/luminescence_transientspec.py
+++ b/lumispy/signals/luminescence_transientspec.py
@@ -25,6 +25,7 @@ import pint
 
 from hyperspy.signals import Signal1D, Signal2D
 from hyperspy._signals.lazy import LazySignal
+from hyperspy.docstrings.signal import OPTIMIZE_ARG
 
 from lumispy.signals import LumiSpectrum, LumiTransient
 from lumispy.signals.common_luminescence import CommonLumi
@@ -69,6 +70,53 @@ class LumiTransientSpectrum(Signal2D, CommonLumi, CommonTransient):
     _signal_type = "TransientSpectrum"
     _signal_dimension = 2
 
+    def spec2nav(self, optimize=True):
+        """Return the streak image as signal with the spectral axis as navigation
+        axis and the time axis as signal axis. For efficient iteration over
+        transients as a function of the spectral positions (e.g. for fitting
+        transients). By default, the method ensures the data is stored optimally,
+        hence often making a copy of the data.
+
+        Parameters
+        ----------
+        %s
+
+        See Also
+        --------
+        lumispy.signals.LumiTransientSpectrum.time2nav
+        hyperspy.api.signals.BaseSignal.transpose
+        """
+        s = self.transpose(signal_axes=[-1],optimize=optimize)
+        return s
+
+    spec2nav.__doc__ %= (
+        OPTIMIZE_ARG.replace("False", "True"),
+    )
+
+    def time2nav(self, optimize=True):
+        """Return the streak image as signal with the time axis as navigation
+        axis and the spectral axis as signal axis. For efficient iteration over
+        spectra as a function of time (e.g. for fitting spectra). By default, the
+        method ensures the data is stored optimally, hence often making a copy
+        of the data.
+
+        Parameters
+        ----------
+        %s
+
+        See Also
+        --------
+        lumispy.signals.LumiTransientSpectrum.time2nav
+        hyperspy.api.signals.BaseSignal.transpose
+        """
+        s = self.transpose(signal_axes=[-2],optimize=optimize)
+        return s
+        #self.axes_manager.signal_axes[-1].navigate = True
+        #self.set_signal_type("LumiSpectrum")
+
+    time2nav.__doc__ %= (
+        OPTIMIZE_ARG.replace("False", "True"),
+    )
 
 class LazyLumiTransientSpectrum(LazySignal, LumiTransientSpectrum):
     """**Lazy 2D luminescence signal class (spectral+transient/time resolved dimensions)**"""

--- a/lumispy/signals/luminescence_transientspec.py
+++ b/lumispy/signals/luminescence_transientspec.py
@@ -74,12 +74,17 @@ class LumiTransientSpectrum(Signal2D, CommonLumi, CommonTransient):
         """Return the streak image as signal with the spectral axis as navigation
         axis and the time axis as signal axis. For efficient iteration over
         transients as a function of the spectral positions (e.g. for fitting
-        transients). By default, the method ensures the data is stored optimally,
+        transients). By default, the method ensures that the data is stored optimally,
         hence often making a copy of the data.
 
         Parameters
         ----------
         %s
+
+        Returns
+        -------
+        signal : LumiSpectrum
+            A signal of type ``LumiTransient``.
 
         See Also
         --------
@@ -97,12 +102,17 @@ class LumiTransientSpectrum(Signal2D, CommonLumi, CommonTransient):
         """Return the streak image as signal with the time axis as navigation
         axis and the spectral axis as signal axis. For efficient iteration over
         spectra as a function of time (e.g. for fitting spectra). By default, the
-        method ensures the data is stored optimally, hence often making a copy
+        method ensures that the data is stored optimally, hence often making a copy
         of the data.
 
         Parameters
         ----------
         %s
+
+        Returns
+        -------
+        signal : LumiSpectrum
+            A signal of type ``LumiSpectrum``.
 
         See Also
         --------

--- a/lumispy/signals/luminescence_transientspec.py
+++ b/lumispy/signals/luminescence_transientspec.py
@@ -91,12 +91,10 @@ class LumiTransientSpectrum(Signal2D, CommonLumi, CommonTransient):
         lumispy.signals.LumiTransientSpectrum.time2nav
         hyperspy.api.signals.BaseSignal.transpose
         """
-        s = self.transpose(signal_axes=[-1],optimize=optimize)
+        s = self.transpose(signal_axes=[-1], optimize=optimize)
         return s
 
-    spec2nav.__doc__ %= (
-        OPTIMIZE_ARG.replace("False", "True"),
-    )
+    spec2nav.__doc__ %= (OPTIMIZE_ARG,)
 
     def time2nav(self, optimize=True):
         """Return the streak image as signal with the time axis as navigation
@@ -119,14 +117,11 @@ class LumiTransientSpectrum(Signal2D, CommonLumi, CommonTransient):
         lumispy.signals.LumiTransientSpectrum.time2nav
         hyperspy.api.signals.BaseSignal.transpose
         """
-        s = self.transpose(signal_axes=[-2],optimize=optimize)
+        s = self.transpose(signal_axes=[-2], optimize=optimize)
         return s
-        #self.axes_manager.signal_axes[-1].navigate = True
-        #self.set_signal_type("LumiSpectrum")
 
-    time2nav.__doc__ %= (
-        OPTIMIZE_ARG.replace("False", "True"),
-    )
+    time2nav.__doc__ %= (OPTIMIZE_ARG,)
+
 
 class LazyLumiTransientSpectrum(LazySignal, LumiTransientSpectrum):
     """**Lazy 2D luminescence signal class (spectral+transient/time resolved dimensions)**"""

--- a/lumispy/tests/signals/test_luminescence_transient_spectrum.py
+++ b/lumispy/tests/signals/test_luminescence_transient_spectrum.py
@@ -69,6 +69,18 @@ class TestLumiTransientSpectrum0D:
         assert s2.axes_manager[-1].units == "nm"
         assert type(s2) == LumiSpectrum
 
+    def test_spec2nav(self):
+        s2 = self.s.spec2nav()
+        assert s2.axes_manager[0].units == "nm"
+        assert s2.axes_manager[-1].units == "ps"
+        assert type(s2) == LumiTransient
+
+    def test_time2nav(self):
+        s2 = self.s.time2nav()
+        assert s2.axes_manager[0].units == "ps"
+        assert s2.axes_manager[-1].units == "nm"
+        assert type(s2) == LumiSpectrum
+
 
 class TestLumiTransientSpectrum2D:
     def setup_method(self, method):
@@ -118,5 +130,17 @@ class TestLumiTransientSpectrum2D:
 
     def test_max_t(self):
         s2 = self.s.max(axis="Time")
+        assert s2.axes_manager[-1].units == "nm"
+        assert type(s2) == LumiSpectrum
+
+    def test_spec2nav(self):
+        s2 = self.s.spec2nav()
+        assert s2.axes_manager[0].units == "nm"
+        assert s2.axes_manager[-1].units == "ps"
+        assert type(s2) == LumiTransient
+
+    def test_time2nav(self):
+        s2 = self.s.time2nav()
+        assert s2.axes_manager[0].units == "ps"
         assert s2.axes_manager[-1].units == "nm"
         assert type(s2) == LumiSpectrum

--- a/upcoming_changes/223.new.rst
+++ b/upcoming_changes/223.new.rst
@@ -1,0 +1,1 @@
+Add functions :meth:`~.signals.luminescence_transientspec.LumiTransientSpectrum.spec2nav` and :meth:`~.signals.luminescence_transientspec.LumiTransientSpectrum.time2nav` to convert either `signal` dimension to a `navigation` dimension for efficient iteration over the respective axes.


### PR DESCRIPTION
### Description of the change
When operating over either time or spectral axes of a `LumiTransientSpectrum` signal, e.g. to fit the same function at all times or all wavelengths/energies, it is convenient to have this dimension as a navigation instead of signal dimension. Therefore, `time2nav` and `spec2nav` functions are added.

### Progress of the PR
- [x] Add functions,
- [x] docstring updated,
- [x] update user guide,
- [x] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/lumispy/lumispy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:lumispy` build of this PR (link in github checks),
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import lumispy as lum
import numpy as np
ax0 = {"name": "Time", "units": "ps", "size": 10}
ax1 = {"name": "Wavelength", "units": "nm", "size": 10}
s = lum.signals.LumiTransientSpectrum(np.ones(100).reshape(10, 10), axes =[ax0, ax1])
s.time2nav().axes_manager
s.spec2nav().axes_manager
```


