### PR TITLE
Add support for python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,3 +86,5 @@ jobs:
       - name: Upload coverage to Codecov
         if: ${{ always() }} && ${{ matrix.PYTEST_ARGS_COVERAGE }} 
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,25 +11,38 @@ jobs:
       MPLBACKEND: agg
       PIP_ARGS: --upgrade -e
       PYTEST_ARGS: --pyargs lumispy
-      PYTEST_ARGS_COVERAGE: 
+      PYTEST_ARGS_COVERAGE: --cov=. --cov-report=xml
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu, windows, macos]
-        PYTHON_VERSION: ['3.8', '3.12']
+        PYTHON_VERSION: ['3.10', '3.12']
         PIP_SELECTOR: ['[tests]',]
         include:
           - os: ubuntu
+            PYTHON_VERSION: '3.11'
+            PIP_SELECTOR: '[tests]'
+          - os: ubuntu
+            PYTHON_VERSION: '3.13'
+            PIP_SELECTOR: '[tests]'
+          # dev
+          - os: ubuntu
+            PYTHON_VERSION: '3.12'
+            PIP_SELECTOR: '[tests]'
+            LABEL: '-dev'
+          # minimum
+          - os: ubuntu
             PYTHON_VERSION: '3.9'
             PIP_SELECTOR: '[tests]'
-          - os: ubuntu
-            PYTHON_VERSION: '3.10'
+            LABEL: '-minimum'
+          # oldest
+          - os: ubuntu 
+            PYTHON_VERSION: '3.9'
             PIP_SELECTOR: '[tests]'
-          - os: ubuntu
-            PYTHON_VERSION: '3.11'
-            PIP_SELECTOR: '[tests, coverage]'
-            PYTEST_ARGS_COVERAGE: --cov=lumispy --cov-report=xml
-            LABEL: '/coverage'
+            LABEL: -release-oldest
+            # Matching pyproject.toml
+            DEPENDENCIES: hyperspy==1.7.3
+
     steps:
       - uses: actions/checkout@v4
 
@@ -48,16 +61,21 @@ jobs:
         run: |
           pip install ${{ env.PIP_ARGS }} .'${{ matrix.PIP_SELECTOR }}'
 
-      - name: Pip list
-        run: |
-          pip list
-
       - name: Install (HyperSpy dev)
         # Test against the hyperspy `RELEASE_next_minor` branch
         if: ${{ matrix.PYTEST_ARGS_COVERAGE }} 
         shell: bash
         run: |
           pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_minor.zip
+
+      - name: Install oldest supported version
+        if: contains( matrix.LABEL, 'oldest')
+        run: |
+          pip install ${{ matrix.DEPENDENCIES }}
+
+      - name: Pip list
+        run: |
+          pip list
 
       - name: Run test suite
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,8 @@ jobs:
           - os: ubuntu
             PYTHON_VERSION: '3.13'
             PIP_SELECTOR: '[tests]'
+            # test for dev as long as HyperSpy 3.13 support is not released
+            LABEL: '-dev'
           # dev
           - os: ubuntu
             PYTHON_VERSION: '3.12'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install (HyperSpy dev)
         # Test against the hyperspy `RELEASE_next_minor` branch
-        if: ${{ matrix.PYTEST_ARGS_COVERAGE }} 
+        if: contains( matrix.LABEL, 'dev')
         shell: bash
         run: |
           pip install https://github.com/hyperspy/hyperspy/archive/RELEASE_next_minor.zip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,17 +13,17 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "hyperspy >= 1.7",  # earlier versions do not provide non-uniform axes
+    "hyperspy >= 1.7.3",  # earlier versions fail on pint dependency
     "numpy",
     "scipy",
     "pint>=0.10",
@@ -61,7 +61,7 @@ keywords = [
 ]
 dynamic = ["version"]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.entry-points."hyperspy.extensions"]
 lumispy = "lumispy"

--- a/upcoming_changes/225.maintenance.rst
+++ b/upcoming_changes/225.maintenance.rst
@@ -1,0 +1,1 @@
+Add support for python 3.13 and drop support for python 3.8


### PR DESCRIPTION
A few sentences and/or a bulleted list to describe and motivate the change:
- Add support for python 3.13
- Drop support for python 3.8
- Test for oldest supported hyperspy version and pin to >=v1.7.3

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/lumispy/lumispy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:lumispy` build of this PR (link in github checks),
- [x] ready for review.
- [x] Test 3.13 against hs-RnMinor as https://github.com/hyperspy/hyperspy/pull/3468 is not yet released