### PR TITLE
Update for API changes in actions/download-artifact@v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
     steps:
     - name: Download dist
       uses: actions/download-artifact@v5
+      with:
+        name: dist
+        path: dist
 
     - name: Display downloaded files
       run: |


### PR DESCRIPTION
Follow up of https://github.com/LumiSpy/lumispy/pull/231: there is an API changes actions/download-artifact v5 and the workflow needs to be updated accordingly.

The release workflow fails on main: https://github.com/ericpre/lumispy/actions/runs/17493851162, while it passes with the changes of this PR: https://github.com/ericpre/lumispy/actions/runs/17493943559.