### PR TITLE
Lazy loading of modules and exposed utility functions

### DIFF
--- a/lumispy/__init__.pyi
+++ b/lumispy/__init__.pyi
@@ -17,6 +17,27 @@
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 
-import lazy_loader
+from . import (
+    components,
+    signals,
+    utils,
+)
+from ._version import __version__
+from .utils.axes import nm2eV, eV2nm, nm2invcm, invcm2nm, join_spectra
+from .utils.io import to_array, savetxt
+from .utils import crop_edges
 
-__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
+__all__ = [
+    "__version__",
+    "components",
+    "signals",
+    "utils",
+    "nm2eV",
+    "eV2nm",
+    "nm2invcm",
+    "invcm2nm",
+    "join_spectra",
+    "to_array",
+    "savetxt",
+    "crop_edges",
+]

--- a/lumispy/_version.py
+++ b/lumispy/_version.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2025 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the license, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+
+import functools
+from importlib.metadata import version
+from pathlib import Path
+
+
+@functools.cache
+def _get_version():
+    version_ = version("hyperspy")
+    # For development version, `setuptools_scm` will be used at build time
+    # to get the dev version, in case of missing vcs information (git archive,
+    # shallow repository), the fallback version defined in pyproject.toml will
+    # be used
+
+    # if we have a editable install from a git repository try to use
+    # `setuptools_scm` to find a more accurate version:
+    # `importlib.metadata` will provide the version at installation
+    # time and for editable version this may be different
+
+    # we only do that if we have enough git history, e.g. not shallow checkout
+    _root = Path(__file__).resolve().parents[1]
+    if (_root / ".git").exists() and not (_root / ".git/shallow").exists():
+        try:
+            # setuptools_scm may not be installed
+            from setuptools_scm import get_version
+
+            version_ = get_version(_root)
+        except ImportError:  # pragma: no cover
+            # setuptools_scm not install, we keep the existing __version__
+            pass
+
+    return version_
+
+
+__version__ = _get_version()

--- a/lumispy/components/__init__.pyi
+++ b/lumispy/components/__init__.pyi
@@ -16,11 +16,4 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-"""
-Module containing model components defined in LumiSpy.
 
-"""
-
-import lazy_loader
-
-__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)

--- a/lumispy/hyperspy_extension.yaml
+++ b/lumispy/hyperspy_extension.yaml
@@ -25,7 +25,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: False
-    module: lumispy.signals.luminescence_spectrum
+    module: lumispy.signals
   LazyLumiSpectrum:
     signal_type: Luminescence
     signal_type_aliases:
@@ -34,7 +34,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: True
-    module: lumispy.signals.luminescence_spectrum
+    module: lumispy.signals
 
   CLSpectrum:
     signal_type: CL
@@ -44,7 +44,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: False
-    module: lumispy.signals.cl_spectrum
+    module: lumispy.signals
   LazyCLSpectrum:
     signal_type: CL
     signal_type_aliases:
@@ -53,7 +53,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: True
-    module: lumispy.signals.cl_spectrum
+    module: lumispy.signals
 
   ELSpectrum:
     signal_type: EL
@@ -63,7 +63,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: False
-    module: lumispy.signals.el_spectrum
+    module: lumispy.signals
   LazyELSpectrum:
     signal_type: EL
     signal_type_aliases:
@@ -72,7 +72,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: True
-    module: lumispy.signals.el_spectrum
+    module: lumispy.signals
 
   PLSpectrum:
     signal_type: PL
@@ -82,7 +82,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: False
-    module: lumispy.signals.pl_spectrum
+    module: lumispy.signals
   LazyPLSpectrum:
     signal_type: PL
     signal_type_aliases:
@@ -91,7 +91,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: True
-    module: lumispy.signals.pl_spectrum
+    module: lumispy.signals
 
   CLSEMSpectrum:
     signal_type: CL_SEM
@@ -101,7 +101,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: False
-    module: lumispy.signals.cl_spectrum
+    module: lumispy.signals
   LazyCLSEMSpectrum:
     signal_type: CL_SEM
     signal_type_aliases:
@@ -110,7 +110,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: True
-    module: lumispy.signals.cl_spectrum
+    module: lumispy.signals
 
   CLSTEMSpectrum:
     signal_type: CL_STEM
@@ -120,7 +120,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: False
-    module: lumispy.signals.cl_spectrum
+    module: lumispy.signals
   LazyCLSTEMSpectrum:
     signal_type: CL_STEM
     signal_type_aliases:
@@ -129,7 +129,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: True
-    module: lumispy.signals.cl_spectrum
+    module: lumispy.signals
 
   LumiTransient:
     signal_type: Transient
@@ -140,7 +140,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: False
-    module: lumispy.signals.luminescence_transient
+    module: lumispy.signals
   LazyLumiTransient:
     signal_type: Transient
     signal_type_aliases:
@@ -150,7 +150,7 @@ signals:
     signal_dimension: 1
     dtype: real
     lazy: True
-    module: lumispy.signals.luminescence_transient
+    module: lumispy.signals
 
   TransientSpectrumCasting: # allows casting to either Luminescence or Transient when dimensionality is reduced
     signal_type: TransientSpectrum
@@ -174,7 +174,7 @@ signals:
     signal_dimension: 2
     dtype: real
     lazy: False
-    module: lumispy.signals.luminescence_transientspec
+    module: lumispy.signals
   LazyLumiTransientSpectrum:
     signal_type: TransientSpectrum
     signal_type_aliases:
@@ -185,4 +185,4 @@ signals:
     signal_dimension: 2
     dtype: real
     lazy: True
-    module: lumispy.signals.luminescence_transientspec
+    module: lumispy.signals

--- a/lumispy/signals/__init__.py
+++ b/lumispy/signals/__init__.py
@@ -16,35 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from .luminescence_spectrum import LumiSpectrum
-from .lazy_luminescence_spectrum import LazyLumiSpectrum
-from .cl_spectrum import CLSpectrum, CLSEMSpectrum, CLSTEMSpectrum
-from .lazy_cl_spectrum import LazyCLSpectrum, LazyCLSEMSpectrum, LazyCLSTEMSpectrum
-from .pl_spectrum import PLSpectrum
-from .lazy_pl_spectrum import LazyPLSpectrum
-from .el_spectrum import ELSpectrum
-from .lazy_el_spectrum import LazyELSpectrum
-from .luminescence_transient import LumiTransient
-from .lazy_luminescence_transient import LazyLumiTransient
-from .luminescence_transientspec import LumiTransientSpectrum
-from .lazy_luminescence_transientspec import LazyLumiTransientSpectrum
+"""
+Modules containing the LumiSpy signals and their lazy counterparts.
 
+"""
 
-__all__ = [
-    "LumiSpectrum",
-    "LazyLumiSpectrum",
-    "CLSpectrum",
-    "LazyCLSpectrum",
-    "CLSEMSpectrum",
-    "LazyCLSEMSpectrum",
-    "CLSTEMSpectrum",
-    "LazyCLSTEMSpectrum",
-    "PLSpectrum",
-    "LazyPLSpectrum",
-    "ELSpectrum",
-    "LazyELSpectrum",
-    "LumiTransient",
-    "LazyLumiTransient",
-    "LumiTransientSpectrum",
-    "LazyLumiTransientSpectrum",
-]
+import lazy_loader
+
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)

--- a/lumispy/signals/__init__.py
+++ b/lumispy/signals/__init__.py
@@ -16,14 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from .luminescence_spectrum import LumiSpectrum, LazyLumiSpectrum
-from .cl_spectrum import CLSpectrum, LazyCLSpectrum
-from .cl_spectrum import CLSEMSpectrum, LazyCLSEMSpectrum
-from .cl_spectrum import CLSTEMSpectrum, LazyCLSTEMSpectrum
-from .pl_spectrum import PLSpectrum, LazyPLSpectrum
-from .el_spectrum import ELSpectrum, LazyELSpectrum
-from .luminescence_transient import LumiTransient, LazyLumiTransient
-from .luminescence_transientspec import LumiTransientSpectrum, LazyLumiTransientSpectrum
+from .luminescence_spectrum import LumiSpectrum
+from .lazy_luminescence_spectrum import LazyLumiSpectrum
+from .cl_spectrum import CLSpectrum, CLSEMSpectrum, CLSTEMSpectrum
+from .lazy_cl_spectrum import LazyCLSpectrum, LazyCLSEMSpectrum, LazyCLSTEMSpectrum
+from .pl_spectrum import PLSpectrum
+from .lazy_pl_spectrum import LazyPLSpectrum
+from .el_spectrum import ELSpectrum
+from .lazy_el_spectrum import LazyELSpectrum
+from .luminescence_transient import LumiTransient
+from .lazy_luminescence_transient import LazyLumiTransient
+from .luminescence_transientspec import LumiTransientSpectrum
+from .lazy_luminescence_transientspec import LazyLumiTransientSpectrum
 
 
 __all__ = [

--- a/lumispy/signals/__init__.pyi
+++ b/lumispy/signals/__init__.pyi
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2025 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the license, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+from .luminescence_spectrum import LumiSpectrum
+from .lazy_luminescence_spectrum import LazyLumiSpectrum
+from .cl_spectrum import CLSpectrum, CLSEMSpectrum, CLSTEMSpectrum
+from .lazy_cl_spectrum import LazyCLSpectrum, LazyCLSEMSpectrum, LazyCLSTEMSpectrum
+from .pl_spectrum import PLSpectrum
+from .lazy_pl_spectrum import LazyPLSpectrum
+from .el_spectrum import ELSpectrum
+from .lazy_el_spectrum import LazyELSpectrum
+from .luminescence_transient import LumiTransient
+from .lazy_luminescence_transient import LazyLumiTransient
+from .luminescence_transientspec import LumiTransientSpectrum
+from .lazy_luminescence_transientspec import LazyLumiTransientSpectrum
+
+__all__ = [
+    "LumiSpectrum",
+    "LazyLumiSpectrum",
+    "CLSpectrum",
+    "LazyCLSpectrum",
+    "CLSEMSpectrum",
+    "LazyCLSEMSpectrum",
+    "CLSTEMSpectrum",
+    "LazyCLSTEMSpectrum",
+    "PLSpectrum",
+    "LazyPLSpectrum",
+    "ELSpectrum",
+    "LazyELSpectrum",
+    "LumiTransient",
+    "LazyLumiTransient",
+    "LumiTransientSpectrum",
+    "LazyLumiTransientSpectrum",
+]
+
+def __dir__():
+    return sorted(__all__)

--- a/lumispy/signals/cl_spectrum.py
+++ b/lumispy/signals/cl_spectrum.py
@@ -17,8 +17,8 @@
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 """
-Signal class for cathodoluminescence spectral data
---------------------------------------------------
+Signal classes for cathodoluminescence spectral data
+----------------------------------------------------
 """
 
 import numpy as np
@@ -141,12 +141,6 @@ class CLSpectrum(LumiSpectrum):
     )
 
 
-class LazyCLSpectrum(LazySignal, CLSpectrum):
-    """**General lazy 1D cathodoluminescence signal class.**"""
-
-    _lazy = True
-
-
 """SEM specific signal class for Cathodoluminescence spectral data.
 """
 
@@ -203,23 +197,7 @@ class CLSEMSpectrum(CLSpectrum):
             self.metadata.set_item("Signal.grating_corrected", True)
 
 
-class LazyCLSEMSpectrum(LazySignal, CLSEMSpectrum):
-    """**Lazy 1D scanning electron microscopy cathodoluminescence signal class.**"""
-
-    _lazy = True
-
-
-"""STEM specific signal class for Cathodoluminescence spectral data.
-"""
-
-
 class CLSTEMSpectrum(CLSpectrum):
     """**1D scanning transmission electron microscopy cathodoluminescence signal class.**"""
 
     _signal_type = "CL_STEM"
-
-
-class LazyCLSTEMSpectrum(LazySignal, CLSTEMSpectrum):
-    """**Lazy 1D scanning transmission electron microscopy cathodoluminescence signal class.**"""
-
-    _lazy = True

--- a/lumispy/signals/cl_spectrum.py
+++ b/lumispy/signals/cl_spectrum.py
@@ -24,8 +24,6 @@ Signal classes for cathodoluminescence spectral data
 import numpy as np
 from warnings import warn
 
-from hyperspy._signals.lazy import LazySignal
-
 from lumispy.signals import LumiSpectrum
 
 

--- a/lumispy/signals/el_spectrum.py
+++ b/lumispy/signals/el_spectrum.py
@@ -21,8 +21,6 @@ Signal class for electroluminescence spectral data
 --------------------------------------------------
 """
 
-from hyperspy._signals.lazy import LazySignal
-
 from lumispy.signals import LumiSpectrum
 
 
@@ -31,9 +29,3 @@ class ELSpectrum(LumiSpectrum):
 
     _signal_type = "EL"
     _signal_dimension = 1
-
-
-class LazyELSpectrum(LazySignal, ELSpectrum):
-    """**General lazy 1D electroluminescence signal class**"""
-
-    _lazy = True

--- a/lumispy/signals/lazy_cl_spectrum.py
+++ b/lumispy/signals/lazy_cl_spectrum.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2025 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the license, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+"""
+Lazy signal classes for cathodoluminescence spectral data
+---------------------------------------------------------
+"""
+
+from hyperspy.docstrings.signal import LAZYSIGNAL_DOC
+from hyperspy.signals import LazySignal1D
+
+from lumispy.signals import CLSpectrum, CLSEMSpectrum, CLSTEMSpectrum
+
+
+class LazyCLSpectrum(LazySignal1D, CLSpectrum):
+    """**General lazy 1D cathodoluminescence signal class.**"""
+
+    __doc__ += LAZYSIGNAL_DOC.replace("__BASECLASS__", "CLSpectrum")
+
+
+class LazyCLSEMSpectrum(LazySignal1D, CLSEMSpectrum):
+    """**Lazy 1D scanning electron microscopy cathodoluminescence signal class.**"""
+
+    __doc__ += LAZYSIGNAL_DOC.replace("__BASECLASS__", "CLSEMSpectrum")
+
+
+class LazyCLSTEMSpectrum(LazySignal1D, CLSTEMSpectrum):
+    """**Lazy 1D scanning transmission electron microscopy cathodoluminescence signal class.**"""
+
+    __doc__ += LAZYSIGNAL_DOC.replace("__BASECLASS__", "CLSTEMSpectrum")
+

--- a/lumispy/signals/lazy_el_spectrum.py
+++ b/lumispy/signals/lazy_el_spectrum.py
@@ -17,15 +17,17 @@
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 """
-Signal class for photoluminescence spectral data
-------------------------------------------------
+Lazy signal class for electroluminescence spectral data
+-------------------------------------------------------
 """
 
-from lumispy.signals import LumiSpectrum
+from hyperspy.docstrings.signal import LAZYSIGNAL_DOC
+from hyperspy.signals import LazySignal1D
+
+from lumispy.signals import ELSpectrum
 
 
-class PLSpectrum(LumiSpectrum):
-    """**General 1D photoluminescence signal class**"""
+class LazyELSpectrum(LazySignal1D, ELSpectrum):
+    """**Lazy general 1D electroluminescence signal class**"""
 
-    _signal_type = "PL"
-    _signal_dimension = 1
+    __doc__ += LAZYSIGNAL_DOC.replace("__BASECLASS__", "ELSpectrum")

--- a/lumispy/signals/lazy_luminescence_spectrum.py
+++ b/lumispy/signals/lazy_luminescence_spectrum.py
@@ -17,15 +17,17 @@
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 """
-Signal class for photoluminescence spectral data
-------------------------------------------------
+Lazy Signal class for luminescence spectral data (1D).
+------------------------------------------------------
 """
+
+from hyperspy.docstrings.signal import LAZYSIGNAL_DOC
+from hyperspy.signals import LazySignal1D
 
 from lumispy.signals import LumiSpectrum
 
 
-class PLSpectrum(LumiSpectrum):
-    """**General 1D photoluminescence signal class**"""
+class LazyLumiSpectrum(LazySignal1D, LumiSpectrum):
+    """**General lazy 1D luminescence signal class.**"""
 
-    _signal_type = "PL"
-    _signal_dimension = 1
+    __doc__ += LAZYSIGNAL_DOC.replace("__BASECLASS__", "LumiSpectrum")

--- a/lumispy/signals/lazy_luminescence_transient.py
+++ b/lumispy/signals/lazy_luminescence_transient.py
@@ -17,15 +17,17 @@
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 """
-Signal class for photoluminescence spectral data
-------------------------------------------------
+Lazy signal class for luminescence transient data (1D)
+------------------------------------------------------
 """
 
-from lumispy.signals import LumiSpectrum
+from hyperspy.docstrings.signal import LAZYSIGNAL_DOC
+from hyperspy.signals import LazySignal1D
+
+from lumispy.signals import LumiTransient
 
 
-class PLSpectrum(LumiSpectrum):
-    """**General 1D photoluminescence signal class**"""
+class LazyLumiTransient(LazySignal1D, LumiTransient):
+    """**General lazy 1D luminescence signal class (transient/time resolved)**"""
 
-    _signal_type = "PL"
-    _signal_dimension = 1
+    __doc__ += LAZYSIGNAL_DOC.replace("__BASECLASS__", "LumiTransient")

--- a/lumispy/signals/lazy_luminescence_transientspec.py
+++ b/lumispy/signals/lazy_luminescence_transientspec.py
@@ -17,15 +17,17 @@
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 """
-Signal class for photoluminescence spectral data
-------------------------------------------------
+Lazy signal class for luminescence transient data (2D)
+------------------------------------------------------
 """
 
-from lumispy.signals import LumiSpectrum
+from hyperspy.docstrings.signal import LAZYSIGNAL_DOC
+from hyperspy.signals import LazySignal2D
+
+from lumispy.signals import LumiTransientSpectrum
 
 
-class PLSpectrum(LumiSpectrum):
-    """**General 1D photoluminescence signal class**"""
+class LazyLumiTransientSpectrum(LazySignal2D, LumiTransientSpectrum):
+    """**Lazy 2D luminescence signal class (spectral+transient/time resolved dimensions)**"""
 
-    _signal_type = "PL"
-    _signal_dimension = 1
+    __doc__ += LAZYSIGNAL_DOC.replace("__BASECLASS__", "LumiTransientSpectrum")

--- a/lumispy/signals/lazy_pl_spectrum.py
+++ b/lumispy/signals/lazy_pl_spectrum.py
@@ -17,15 +17,17 @@
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
 """
-Signal class for photoluminescence spectral data
-------------------------------------------------
+Lazy signal class for photoluminescence spectral data
+-----------------------------------------------------
 """
 
-from lumispy.signals import LumiSpectrum
+from hyperspy.docstrings.signal import LAZYSIGNAL_DOC
+from hyperspy.signals import LazySignal1D
+
+from lumispy.signals import PLSpectrum
 
 
-class PLSpectrum(LumiSpectrum):
-    """**General 1D photoluminescence signal class**"""
+class LazyPLSpectrum(LazySignal1D, PLSpectrum):
+    """**Lazy general 1D photoluminescence signal class**"""
 
-    _signal_type = "PL"
-    _signal_dimension = 1
+    __doc__ += LAZYSIGNAL_DOC.replace("__BASECLASS__", "PLSpectrum")

--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -25,7 +25,6 @@ import numpy as np
 from warnings import warn
 
 from hyperspy.signals import Signal1D
-from hyperspy._signals.lazy import LazySignal
 from traits.api import Undefined
 
 from lumispy.signals.common_luminescence import CommonLumi
@@ -355,9 +354,3 @@ class LumiSpectrum(Signal1D, CommonLumi):
         if center_of_mass.axes_manager.navigation_size > 0:
             center_of_mass = center_of_mass.transpose()
         return center_of_mass
-
-
-class LazyLumiSpectrum(LazySignal, LumiSpectrum):
-    """**General lazy 1D luminescence signal class.**"""
-
-    _lazy = True

--- a/lumispy/signals/luminescence_transient.py
+++ b/lumispy/signals/luminescence_transient.py
@@ -22,7 +22,6 @@ Signal class for luminescence transient data (1D)
 """
 
 from hyperspy.signals import Signal1D
-from hyperspy._signals.lazy import LazySignal
 
 from lumispy.signals.common_transient import CommonTransient
 
@@ -35,9 +34,3 @@ class LumiTransient(Signal1D, CommonTransient):
 
     def __init(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-
-class LazyLumiTransient(LazySignal, LumiTransient):
-    """**General lazy 1D luminescence signal class (transient/time resolved)**"""
-
-    _lazy = True

--- a/lumispy/signals/luminescence_transientspec.py
+++ b/lumispy/signals/luminescence_transientspec.py
@@ -24,7 +24,6 @@ Signal class for luminescence transient data (2D)
 import pint
 
 from hyperspy.signals import Signal1D, Signal2D
-from hyperspy._signals.lazy import LazySignal
 from hyperspy.docstrings.signal import OPTIMIZE_ARG
 
 from lumispy.signals import LumiSpectrum, LumiTransient
@@ -121,9 +120,3 @@ class LumiTransientSpectrum(Signal2D, CommonLumi, CommonTransient):
         return s
 
     time2nav.__doc__ %= (OPTIMIZE_ARG,)
-
-
-class LazyLumiTransientSpectrum(LazySignal, LumiTransientSpectrum):
-    """**Lazy 2D luminescence signal class (spectral+transient/time resolved dimensions)**"""
-
-    _lazy = True

--- a/lumispy/tests/signals/test_cl_sem_spectrum.py
+++ b/lumispy/tests/signals/test_cl_sem_spectrum.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-import hyperspy
 import numpy as np
 import pytest
 
@@ -24,9 +23,6 @@ from lumispy.signals import CLSEMSpectrum
 
 
 class TestCLSEMSpectrum:
-    @pytest.mark.skipif(
-        hyperspy.__version__ == "1.6.2", reason="Broken with hyperspy 1.6.2"
-    )
     @pytest.mark.parametrize("nx, ny", [(10, 20), (20, 10)])
     def test_correct_grating_shift(self, nx, ny):
         calx, corg, fov = 1e-10, 1e-10, 1e-10
@@ -44,9 +40,6 @@ class TestCLSEMSpectrum:
         s2.shift1D(barray)
         np.testing.assert_allclose(s2.data, s.data)
 
-    @pytest.mark.skipif(
-        hyperspy.__version__ == "1.6.2", reason="Broken with hyperspy 1.6.2"
-    )
     def test_double_correct_grating_shift(self):
         s = CLSEMSpectrum(np.ones((10, 10, 10)))
         s.correct_grating_shift(1e-10, 1e-10, 1e-10)

--- a/lumispy/tests/signals/test_cl_spectrum.py
+++ b/lumispy/tests/signals/test_cl_spectrum.py
@@ -21,7 +21,7 @@ import pytest
 
 from inspect import getfullargspec
 
-from lumispy.signals.cl_spectrum import CLSpectrum
+from lumispy.signals import CLSpectrum
 
 
 param_list_signal_mask = [

--- a/lumispy/tests/signals/test_luminescence_spectrum.py
+++ b/lumispy/tests/signals/test_luminescence_spectrum.py
@@ -19,7 +19,8 @@
 import numpy as np
 import pytest
 
-from lumispy.signals.luminescence_spectrum import LumiSpectrum
+from lumispy.signals import LumiSpectrum
+
 from hyperspy._signals.signal2d import Signal2D
 from numpy.testing import assert_allclose
 

--- a/lumispy/tests/signals/test_luminescence_transient_spectrum.py
+++ b/lumispy/tests/signals/test_luminescence_transient_spectrum.py
@@ -18,7 +18,7 @@
 
 import numpy as np
 
-from lumispy.signals import LumiSpectrum, LumiTransient, LumiTransientSpectrum
+from lumispy.signals import LumiTransientSpectrum, LumiSpectrum, LumiTransient
 
 
 class TestLumiTransientSpectrum0D:

--- a/lumispy/utils/__init__.py
+++ b/lumispy/utils/__init__.py
@@ -16,17 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-from .axes import (
-    axis2eV,
-    data2eV,
-    var2eV,
-    axis2invcm,
-    data2invcm,
-    var2invcm,
-    solve_grating_equation,
-)
+"""
+Module containing utility functions for LumiSpy.
 
-from .signals import (
-    com,
-    crop_edges,
-)
+"""
+
+import lazy_loader
+
+__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)

--- a/lumispy/utils/__init__.pyi
+++ b/lumispy/utils/__init__.pyi
@@ -16,11 +16,17 @@
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
 
-"""
-Module containing model components defined in LumiSpy.
+from .axes import (
+    axis2eV,
+    data2eV,
+    var2eV,
+    axis2invcm,
+    data2invcm,
+    var2invcm,
+    solve_grating_equation,
+)
 
-"""
-
-import lazy_loader
-
-__getattr__, __dir__, __all__ = lazy_loader.attach_stub(__name__, __file__)
+from .signals import (
+    com,
+    crop_edges,
+)

--- a/lumispy/utils/signals.py
+++ b/lumispy/utils/signals.py
@@ -23,9 +23,9 @@ Utility functions used in signal classes.
 
 import numpy as np
 from hyperspy.axes import FunctionalDataAxis
-from scipy.ndimage import center_of_mass
-from scipy.interpolate import interp1d
+import scipy
 from warnings import warn
+
 
 CROP_EDGES_DOCSTRING = """
     Crop the amount of pixels from the four edges of the scanning
@@ -112,11 +112,11 @@ def com(spectrum_intensities, signal_axis, **kwargs):
         else:
             y = [axis_array[index], axis_array[index + 1]]
             x = [0, 1]
-            fx = interp1d(x, y, **kwargs)
+            fx = scipy.interpolate.interp1d(x, y, **kwargs)
             return float(fx(rem))
 
     # Find center of mass wrt array index
-    index_com = float(center_of_mass(spectrum_intensities)[0])
+    index_com = float(scipy.ndimage.center_of_mass(spectrum_intensities)[0])
 
     # Check for the type of hyperspy.axis
     if type(signal_axis) == FunctionalDataAxis:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "hyperspy >= 1.7.3",  # earlier versions fail on pint dependency
+    # lazy implementation relies on hyperspy-dev
+    "hyperspy @ git+https://github.com/hyperspy/hyperspy.git@RELEASE_next_patch",
+    "lazy-loader",
     "numpy",
     "scipy",
     "pint>=0.10",


### PR DESCRIPTION
### Description of the change
Import of LumiSpy is rather slow (`1.6 s` on linux) mainly due to the direct loading of `Signal1D` from HyperSpy. This PR uses <s>`__getattr__` as proposed by GitHub Copilot</s> `lazy-loader` to load both the sub-modules and utility functions exposed at the top level of LumiSpy using a lazy approach.

Splits off lazy signal modules in line with https://github.com/hyperspy/hyperspy/pull/3569.

### Progress of the PR
- [X] Change implemented (can be split into several points),
- [n/a] docstring updated (if appropriate),
- [n/a] update user guide (if appropriate),
- [X] added tests -> existing tests run through,
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/lumispy/lumispy/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:lumispy` build of this PR (link in github checks),
- [ ] ready for review.

### See also
Implementation in https://github.com/hyperspy/exspy/pull/160 and https://github.com/hyperspy/holospy/pull/65

### Minimal example of the bug fix or the new feature
```python
import time, importlib

t0 = time.perf_counter()
importlib.import_module("lumispy")
print("import time:", time.perf_counter()-t0)

```


