### PR TITLE
fixed the lumispy test_suit_error caused by pint

### DIFF
--- a/lumispy/utils/axes.py
+++ b/lumispy/utils/axes.py
@@ -34,6 +34,7 @@ from hyperspy.axes import DataAxis, UniformDataAxis
 # Functions needed for signal axis conversion
 #
 
+
 def _n_air(x):
     """Refractive index of air as a function of WL in nm.
     This analytical function is correct for the range 185-1700 nm.

--- a/lumispy/utils/signals.py
+++ b/lumispy/utils/signals.py
@@ -18,7 +18,6 @@
 
 """
 Utility functions used in signal classes.
-
 """
 
 import numpy as np
@@ -201,14 +200,19 @@ def crop_edges(
     """
 
     def range_formatting(str_list):
-        if len(str_list) == 2:
-            px = S[0].inav[: str_list[0]].axes_manager.navigation_shape[0]
-            px_list = [px, -px]
-        else:
-            # Pairwaise formatting with [top, left, right, bottom] when len(str_list) == 4
-            px_x = S[0].inav[: str_list[0], :].axes_manager.navigation_shape[0]
-            px_y = S[0].inav[:, : str_list[1]].axes_manager.navigation_shape[1]
-            px_list = [px_x, -px_y, -px_x, px_y]
+        try:
+            if len(str_list) == 2:
+                px = S[0].inav[: str_list[0]].axes_manager.navigation_shape[0]
+                px_list = [px, -px]
+            else:
+                px_x = S[0].inav[: str_list[0], :].axes_manager.navigation_shape[0]
+                px_y = S[0].inav[:, : str_list[1]].axes_manager.navigation_shape[1]
+                px_list = [px_x, -px_y, -px_x, px_y]
+        except Exception as e:
+            raise ValueError(
+                f"Invalid crop_range string(s): {str_list}. Original error was: {e}"
+            ) from e
+
         return np.array(px_list, dtype=int)
 
     # Deprecation warning (for compatibility with ``crop_px``)

--- a/upcoming_changes/257.maintenance.rst
+++ b/upcoming_changes/257.maintenance.rst
@@ -1,0 +1,1 @@
+Fixed lumispy test suit error see: https://github.com/hyperspy/hyperspy-extensions-list/issues/90

--- a/upcoming_changes/257.maintenance.rst
+++ b/upcoming_changes/257.maintenance.rst
@@ -1,1 +1,1 @@
-Fixed lumispy test suit error see: https://github.com/hyperspy/hyperspy-extensions-list/issues/90
+Fixed lumispy test suite error, see https://github.com/hyperspy/hyperspy-extensions-list/issues/90


### PR DESCRIPTION
Fixed the lumispy test_suit_error. Because of a change in pint in test_crop_edges_fancy_str got Dimensionality Error instead of an expected ValueError. https://github.com/hyperspy/hyperspy-extensions-list/issues/90

### Progress of the PR
- [ ] Change implemented (can be split into several points),
- [ ] docstring updated (if appropriate),
- [ ] update user guide (if appropriate),
- [ ] added tests,
- [ ] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/lumispy/lumispy/blob/main/upcoming_changes/README.rst)),
- [ ] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:lumispy` build of this PR (link in github checks),
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
pytest -k "crop_edges_fancy_str" -vv
```


