### PR TITLE
Speed up centroid function, only for uniform axis

### DIFF
--- a/lumispy/signals/luminescence_spectrum.py
+++ b/lumispy/signals/luminescence_spectrum.py
@@ -21,6 +21,7 @@ Signal class for luminescence spectral data (1D).
 -------------------------------------------------
 """
 
+import lumispy
 import numpy as np
 from warnings import warn
 
@@ -78,7 +79,7 @@ class LumiSpectrum(Signal1D, CommonLumi):
         """
         warn(
             "The use of `remove_background_from_file` is deprecated and will "
-            "be removed in LumiSpy 1.0. Please use `remove_background_signal` "
+            "be removed in LumiSpy 1.0. Please use `remove_background` "
             "from the Signal1D class.",
             DeprecationWarning,
             stacklevel=2,
@@ -291,6 +292,7 @@ array([[ 0.,  0.,  1.,  2.,  3.,  4.],
         "\n", "\n\t"
     )
 
+    
     def centroid(self, signal_range=None, **kwargs):
         """Find the centroid (center of mass) of a peak.
 
@@ -323,7 +325,24 @@ array([[ 0.,  0.,  1.,  2.,  3.,  4.],
             on the dimensionality the type is Signal2D or a BaseSignal (for single
             spectrum).
         """
-        if signal_range:
+
+        def _uniform_com(spectrum_intensities, signal_axis):
+            return np.sum(signal_axis.axis * spectrum_intensities) / np.sum(spectrum_intensities)
+
+        def _nonuniform_com(spectrum_intensities, signal_axis, **kwargs):
+            from scipy.ndimage import center_of_mass
+            index = float(center_of_mass(spectrum_intensities)[0])
+            rem = index % 1
+            index = int(index // 1)
+            if rem == 0:
+                return signal_axis.axis[index]
+            else:
+                y = [spectrum_intensities[index], spectrum_intensities[index + 1]]
+                x = [0, 1]
+                fx = np.interp1d(x, y, **kwargs)
+                return float(fx(rem))
+
+        if signal_range is not None:
             if not isinstance(signal_range, tuple):
                 raise TypeError(
                     "The `signal_range` parameter must be a tuple of length 2."
@@ -340,7 +359,10 @@ array([[ 0.,  0.,  1.,  2.,  3.,  4.],
             s = self
 
         signal_axis = s.axes_manager.signal_axes[0]
-        center_of_mass = s.map(com, signal_axis=signal_axis, inplace=False)
+        if signal_axis.is_uniform:
+            center_of_mass = s.map(_uniform_com, signal_axis=signal_axis, inplace=False)
+        else:
+            center_of_mass = s.map(_nonuniform_com, signal_axis=signal_axis, inplace=False)
 
         # Transfer axes metadata to title
         center_of_mass.metadata.General.title = "Centroid map"

--- a/lumispy/tests/signals/test_luminescence_spectrum.py
+++ b/lumispy/tests/signals/test_luminescence_spectrum.py
@@ -105,7 +105,7 @@ class TestLumiSpectrum:
         assert_allclose(s.axes_manager.signal_axes[0].axis[0], 368.614, atol=0.1)
         assert_allclose(s.axes_manager.signal_axes[0].axis[-1], 768.249, atol=0.1)
 
-    def test_center_of_mass(self):
+    def test_center_of_mass_uniform(self):
         s = LumiSpectrum([1, 2, 3, 2, 1, 0])
         ax = s.axes_manager.signal_axes[0]
         ax.offset = 200
@@ -120,6 +120,12 @@ class TestLumiSpectrum:
             com.metadata.General.title
             == f"Centroid map of {ax.name} ({ax.units}) for test_signal"
         )
+
+    def test_center_of_mass_non_uniform(self):
+        s = LumiSpectrum([1, 2, 3, 2, 1, 0], axes=[{"axis": [200, 300, 400, 500, 600, 700]}])
+
+        com = s.centroid()
+        assert_allclose(com.data, 400.0, atol=0.1)
 
     def test_center_of_mass_signalrange(self):
         s = LumiSpectrum([100, 100, 1, 2, 3, 2, 1, 0, 100, 100])
@@ -150,3 +156,4 @@ class TestLumiSpectrum:
         )
         assert com.metadata.General.title == "Centroid map"
         assert isinstance(com, Signal2D)
+

--- a/lumispy/tests/utils/test_signals.py
+++ b/lumispy/tests/utils/test_signals.py
@@ -18,7 +18,7 @@
 
 from lumispy.utils.signals import com, crop_edges
 from hyperspy.axes import FunctionalDataAxis, DataAxis, UniformDataAxis
-from numpy import ones, array
+from numpy import ones, array, arange
 from numpy.testing import assert_allclose
 from pytest import raises, mark, warns
 from hyperspy.signals import Signal1D, Signal2D
@@ -78,9 +78,13 @@ def test_com_inputs():
     with raises(ValueError):
         com(ones(3), ones(2))
     with raises(
-        ValueError, match="The parmeter `signal_axis` must be a HyperSpy Axis object."
+        ValueError, match="The parameter `signal_axis` must be a HyperSpy Axis object."
     ):
         com(ones(3), "string")
+
+def test_com_deprecation_warning():
+    with warns(DeprecationWarning):
+        _ = com(arange(10), arange(10))
 
 
 #

--- a/lumispy/utils/signals.py
+++ b/lumispy/utils/signals.py
@@ -97,15 +97,21 @@ def com(spectrum_intensities, signal_axis, **kwargs):
     >>> center_of_mass = com(intensities, signal_axis)
     >>> print(center_of_mass)  # Outputs: [400.0]
     """
-
+    warn(
+        "The use of `lumispy.utils.signals.com` is deprecated and will be removed "
+        "in LumiSpy 1.0. Please use `lumispy.signals.luminescense_spectrum.centroid` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    
     def _interpolate_signal(axis_array, index, **kwargs):
         """Wrapper for `hs.axes.index2value`.
-
-        Linearly interpolate between values should the index passed not be a
+        
+        Linearly interpolate between values should the index passed not be an
         integer. Using the kwargs, the interpolation method can be changed.
         """
         rem = index % 1
-        index = int(index // 1)
+        index  = int(index // 1)
         if rem == 0:
             return axis_array[int(index)]
         else:
@@ -120,7 +126,7 @@ def com(spectrum_intensities, signal_axis, **kwargs):
     # Check for the type of hyperspy.axis
     if isinstance(signal_axis, FunctionalDataAxis):
         # Calculate value y from x[index_com]
-        x = _interpolate_signal(signal_axis.x.axis, index_com)
+        x = _interpolate_signal(signal_axis.x.axis, index_com, **kwargs)
         kwargs = {}
         for kwarg in signal_axis.parameters_list:
             kwargs[kwarg] = getattr(signal_axis, kwarg)
@@ -128,18 +134,18 @@ def com(spectrum_intensities, signal_axis, **kwargs):
 
     elif hasattr(signal_axis, "axis"):
         # Calculate value interpolating between index_com 0 and 1
-        com_val = _interpolate_signal(signal_axis.axis, index_com)
+        com_val = _interpolate_signal(signal_axis.axis, index_com, **kwargs)
     elif type(signal_axis) in (list, np.ndarray, tuple):
         # Check for dimensionality
-        if len(spectrum_intensities) != len(signal_axis):
+        if len(signal_axis) != len(spectrum_intensities):
             raise ValueError(
                 f"The length of the spectrum array {len(spectrum_intensities)} must match "
-                "the length of the wavelength array {len(signal_axis)}."
+                f"the length of the wavelength array {len(signal_axis)}."
             )
         # Calculate value interpolating between index_com 0 and 1
-        com_val = _interpolate_signal(np.array(signal_axis), index_com)
+        com_val = _interpolate_signal(np.array(signal_axis), index_com, **kwargs)
     else:
-        raise ValueError("The parmeter `signal_axis` must be a HyperSpy Axis object.")
+        raise ValueError("The parameter `signal_axis` must be a HyperSpy Axis object.")
 
     return com_val
 

--- a/upcoming_changes/261.enhancements.rst
+++ b/upcoming_changes/261.enhancements.rst
@@ -1,0 +1,1 @@
+Improved the speed of the centroid function for uniform axis


### PR DESCRIPTION
intergrated jordiferrero's faster centroid function, and split uniform and non uniform approach into two private functions, added a deprecationwarning to the old one.

### Description of the change
Left the centroid function for non-uniform unchanged. Only added a check for uniformity of the axis to the use jordiferreris's solution of PR 179.

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] docstring updated (if appropriate),
- [x] update user guide (if appropriate),
- [x] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/lumispy/lumispy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:lumispy` build of this PR (link in github checks),
- [x] ready for review.


