### PR TITLE
convolved gaussian with one and two exponential as first component for lumispy

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -112,7 +112,6 @@ def run_apidoc(_):
     modules = os.path.normpath(os.path.join(cur_dir, "../lumispy"))
     exclude_pattern = [
         "../lumispy/tests",
-        "../lumispy/components",
         "../lumispy/release_info.py",
     ]
     main(["-e", "-f", "-P", "-o", output_path, modules, *exclude_pattern])

--- a/lumispy/components/__init__.py
+++ b/lumispy/components/__init__.py
@@ -15,3 +15,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+from .convolved_gaussian_exponential import ConvGaussExp
+from .convolved_gaussian_two_exponential import ConvGaussTwoExp
+
+__all__ = [
+    "ConvGaussExp",
+    "ConvGaussTwoExp",
+]
+
+
+def __dir__():
+    return sorted(__all__)

--- a/lumispy/components/convolved_gaussian_exponential.py
+++ b/lumispy/components/convolved_gaussian_exponential.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2026 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the license, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+import numpy as np
+
+import hyperspy.api as hs
+
+sigma2fwhm = 2 * np.sqrt(2 * np.log(2))
+
+
+class ConvGaussExp(hs.model.components1D.Expression):
+    r"""Analytical convolution of Gaussian instrument response function and
+    exponential decay function.
+
+    .. math::
+
+        f(x) = \frac{h}{2} \cdot \exp\left[\frac{\sigma^2}{2\tau^2} - \frac{x - t_0}{\tau}\right] \cdot \left[\operatorname{erfc}\left(\frac{\sigma^2 - \tau(x - t_0)}{\sqrt{2}\sigma\tau}\right)\right]
+
+    =============== ==============
+     Variable        Parameter
+    =============== ==============
+     :math:`h`       height
+     :math:`t_0`     t0
+     :math:`\sigma`  sigma
+     :math:`\tau`    tau
+    =============== ==============
+
+    Parameters
+    ----------
+    height: float
+        Height parameter.
+    t0: float
+        Location parameter.
+    sigma: float
+        Scale (width) parameter of the Gaussian distribution.
+    tau: float
+        Decay parameter (lifetime) of the exponential function.
+    **kwargs
+        Extra keyword arguments that are passed to the
+        :py:class:`hyperspy._components.expression.Expression` component.
+
+    Attributes
+    ----------
+    fwhm: float
+        Convenience attribute to get and set the full width at half maximum.
+    A: float
+        Convenience attribute to get and set the area and defined for
+        compatibility with `Gaussian` component.
+    """
+
+    def __init__(
+        self,
+        height=1.0,
+        t0=0.0,
+        sigma=10.0,
+        tau=100.0,
+        module=["numpy", "scipy"],
+        **kwargs,
+    ):
+        super().__init__(
+            expression="1/2*height*exp(sigma**2/(2*tau**2)-((x-t0)/tau))*\
+                    erfc((sigma**2-tau*(x-t0))/(sqrt(2)*sigma*tau))",
+            name="ConvGaussExp",
+            height=height,
+            t0=t0,
+            sigma=sigma,
+            tau=tau,
+            position="t0",
+            module=module,
+            **kwargs,
+        )
+        # Id for hyperspy
+        self._id_name = "049a5740-389b-4d7a-bab9-a6a7afc5c498"
+
+        # Boundaries
+        self.height.bmin = 0.0
+        self.height.bmax = None
+
+        self.sigma.bmin = 1e-12
+        self.sigma.bmax = None
+
+        self.tau.bmin = 1.0
+        self.tau.bmax = None
+
+        self.isbackground = False
+        self.convolved = False
+
+    @property
+    def fwhm(self):
+        return self.sigma.value * sigma2fwhm
+
+    @fwhm.setter
+    def fwhm(self, value):
+        self.sigma.value = value / sigma2fwhm
+
+    @property
+    def A(self):
+        return self.height.value * self.tau.value
+
+    @A.setter
+    def A(self, value):
+        self.height.value = value / self.tau.value

--- a/lumispy/components/convolved_gaussian_two_exponential.py
+++ b/lumispy/components/convolved_gaussian_two_exponential.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2026 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the license, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+import numpy as np
+
+import hyperspy.api as hs
+
+sigma2fwhm = 2 * np.sqrt(2 * np.log(2))
+
+
+class ConvGaussTwoExp(hs.model.components1D.Expression):
+    r"""Analytical convolution of Gaussian instrument response function and two
+    exponential decay functions.
+
+    .. math::
+
+        f(x) = \frac{h_1}{2} \cdot \exp\left[\frac{\sigma^2}{2\tau^2_1} - \frac{x - t_0}{\tau_1}\right] \cdot
+        \left[\operatorname{erfc}\left(\frac{\sigma^2 - \tau_1(x - t_0)}{\sqrt{2}\sigma\tau_1}\right)\right] +
+        \frac{h_2}{2} \cdot \exp\left[\frac{\sigma^2}{2\tau^2_2} - \frac{x - t_0}{\tau_2}\right] \cdot
+        \left[\operatorname{erfc}\left(\frac{\sigma^2 - \tau_2(x - t_0)}{\sqrt{2}\sigma\tau_2}\right)\right]
+
+    =============== ==============
+     Variable        Parameter
+    =============== ==============
+     :math:`h_1`     height1
+     :math:`h_2`     height2
+     :math:`t_0`     t0
+     :math:`\sigma`  sigma
+     :math:`\tau_1`  tau1
+     :math:`\tau_2`  tau2
+    =============== ==============
+
+    Parameters
+    ----------
+    height1: float
+        Height parameter of the first exponential.
+    height2: float
+        Height parameter of the second exponential.
+    t0: float
+        Location parameter.
+    sigma: float
+        Scale (width) parameter of the Gaussian distribution.
+    tau1: float
+        Decay parameter (lifetime) of the first exponential function.
+    tau2: float
+        Decay parameter (lifetime) of the second exponential function.
+
+    **kwargs
+        Extra keyword arguments that are passed to the
+        :py:class:`hyperspy._components.expression.Expression` component.
+
+    Attributes
+    ----------
+    fwhm: float
+        Convenience attribute to get and set the full width at half maximum.
+    A: float
+        Convenience attribute to get and set the area and defined for
+        compatibility with `Gaussian` component.
+    """
+
+    def __init__(
+        self,
+        height1=1.0,
+        height2=1.0,
+        t0=0.0,
+        sigma=10.0,
+        tau1=100.0,
+        tau2=80.0,
+        module=["numpy", "scipy"],
+        **kwargs,
+    ):
+        super().__init__(
+            expression="1/2*height1*exp(sigma**2/(2*tau1**2)-((x-t0)/tau1))*\
+                    erfc((sigma**2-tau1*(x-t0))/(sqrt(2)*sigma*tau1))+\
+                    1/2*height2*exp(sigma**2/(2*tau2**2)-((x-t0)/tau2))*\
+                    erfc((sigma**2-tau2*(x-t0))/(sqrt(2)*sigma*tau2))",
+            name="ConvGaussTwoExp",
+            height1=height1,
+            height2=height2,
+            t0=t0,
+            sigma=sigma,
+            tau1=tau1,
+            tau2=tau2,
+            position="t0",
+            module=module,
+            **kwargs,
+        )
+        #
+        self._id_name = "bfda25c1-c1f5-4ff8-86d5-94cc659152d4"
+
+        # Boundaries
+        self.height1.bmin = 0.0
+        self.height1.bmax = None
+
+        self.height2.bmin = 0.0
+        self.height2.bmax = None
+
+        self.sigma.bmin = 1e-12
+        self.sigma.bmax = None
+
+        self.tau1.bmin = 1.0
+        self.tau1.bmax = None
+
+        self.tau2.bmin = 1.0
+        self.tau2.bmax = None
+
+        self.isbackground = False
+        self.convolved = False
+
+    @property
+    def fwhm(self):
+        return self.sigma.value * sigma2fwhm
+
+    @fwhm.setter
+    def fwhm(self, value):
+        self.sigma.value = value / sigma2fwhm
+
+    @property
+    def A(self):
+        return (
+            self.height1.value * self.tau1.value + self.height2.value * self.tau2.value
+        )
+
+    @property
+    def A1(self):
+        return self.height1.value * self.tau1.value
+
+    @A1.setter
+    def A1(self, value):
+        self.height1.value = value / self.tau1.value
+
+    @property
+    def A2(self):
+        return self.height2.value * self.tau2.value
+
+    @A2.setter
+    def A2(self, value):
+        self.height2.value = value / self.tau2.value

--- a/lumispy/hyperspy_extension.yaml
+++ b/lumispy/hyperspy_extension.yaml
@@ -186,3 +186,11 @@ signals:
     dtype: real
     lazy: True
     module: lumispy.signals.luminescence_transientspec
+
+components1D:
+  049a5740-389b-4d7a-bab9-a6a7afc5c498:
+    module: lumispy.components.convolved_gaussian_exponential
+    class: ConvGaussExp
+  bfda25c1-c1f5-4ff8-86d5-94cc659152d4:
+    module: lumispy.components.convolved_gaussian_two_exponential
+    class: ConvGaussTwoExp

--- a/lumispy/tests/component/test_convolved_gaussian_exponential.py
+++ b/lumispy/tests/component/test_convolved_gaussian_exponential.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2026 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the license, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+import pytest
+import numpy as np
+import hyperspy.api as hs
+
+from lumispy.components import ConvGaussExp
+
+sigma2fwhm = 2 * np.sqrt(2 * np.log(2))
+
+
+class TestConvGaussExp:
+    def setup_method(self, method):
+        self.s = hs.signals.Signal1D(np.zeros(1024))
+        self.s.axes_manager[0].offset = 10
+        self.s.axes_manager[0].scale = 0.5
+        m = self.s.create_model()
+        m.append(ConvGaussExp(height=3, t0=35, sigma=10, tau=100))
+        m.assign_current_values_to_all()
+        self.m = m
+
+    @pytest.mark.parametrize(("binned"), (True, False))
+    def test_fit(self, binned):
+        self.m.signal.axes_manager[-1].is_binned = binned
+        s = self.m.as_signal()
+        assert s.axes_manager[-1].is_binned == binned
+        g = ConvGaussExp(height=1.5, t0=20.0, sigma=6.0, tau=60.0)
+        m = s.create_model()
+        m.append(g)
+        m.fit(bounded=True)
+        np.testing.assert_allclose(g.height.value, 3.0)
+        np.testing.assert_allclose(g.t0.value, 35.0)
+        np.testing.assert_allclose(g.sigma.value, 10.0)
+        np.testing.assert_allclose(g.tau.value, 100.0)
+
+    def test_util_fwhm_set(self):
+        g = ConvGaussExp()
+        g.fwhm = 1.0
+        np.testing.assert_allclose(g.sigma.value, 1.0 / sigma2fwhm)
+
+    def test_util_fwhm_get(self):
+        g = ConvGaussExp(sigma=1.0)
+        np.testing.assert_allclose(g.fwhm, 1.0 * sigma2fwhm)
+
+    def test_normalization(self):
+        m = self.s.create_model()
+        m.append(ConvGaussExp(height=5.0, sigma=1e-12, tau=100.0))
+        m.assign_current_values_to_all()
+        s = m.as_signal()
+        m1 = s.create_model()
+        m1.append(ConvGaussExp(sigma=1e-12, t0=0.0))
+        m1[0].sigma.free = False
+        m1[0].t0.free = False
+        m1.fit(bounded=True)
+        m2 = s.create_model()
+        m2.append(hs.model.components1D.Exponential())
+        m2.fit(bounded=True)
+        np.testing.assert_allclose(m1[0].height.value, m2[0].A.value, rtol=1e-3)
+        np.testing.assert_allclose(m1[0].tau.value, m2[0].tau.value, rtol=1e-3)

--- a/lumispy/tests/component/test_convolved_gaussian_two_exponential.py
+++ b/lumispy/tests/component/test_convolved_gaussian_two_exponential.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2026 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the license, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+import pytest
+import numpy as np
+import hyperspy.api as hs
+
+from lumispy.components import ConvGaussTwoExp
+
+sigma2fwhm = 2 * np.sqrt(2 * np.log(2))
+
+
+class TestConvGaussTwoExp:
+    def setup_method(self, method):
+        s = hs.signals.Signal1D(np.zeros(1024))
+        s.axes_manager[0].offset = 10
+        s.axes_manager[0].scale = 0.5
+        m = s.create_model()
+        m.append(
+            ConvGaussTwoExp(height1=3, height2=2, t0=35, sigma=10, tau1=100, tau2=80)
+        )
+        m.assign_current_values_to_all()
+        self.m = m
+
+    @pytest.mark.parametrize(("binned"), (True, False))
+    def test_fit(self, binned):
+        self.m.signal.axes_manager[-1].is_binned = binned
+        s = self.m.as_signal()
+        assert s.axes_manager[-1].is_binned == binned
+        g = ConvGaussTwoExp(
+            height1=2.8, height2=1.8, t0=34.0, sigma=9.0, tau1=90.0, tau2=70.0
+        )
+        m = s.create_model()
+        m.append(g)
+        m.fit(bounded=True)
+        np.testing.assert_allclose(g.t0.value, 35.0)
+        np.testing.assert_allclose(g.sigma.value, 10.0)
+
+        expected_components = sorted(
+            [
+                (100.0, 3.0),
+                (80.0, 2.0),
+            ]
+        )
+        fitted_components = sorted(
+            [
+                (g.tau1.value, g.height1.value),
+                (g.tau2.value, g.height2.value),
+            ]
+        )
+        np.testing.assert_allclose(fitted_components, expected_components)
+
+    def test_util_fwhm_set(self):
+        g = ConvGaussTwoExp()
+        g.fwhm = 1.0
+        np.testing.assert_allclose(g.sigma.value, 1.0 / sigma2fwhm)
+
+    def test_util_fwhm_get(self):
+        g = ConvGaussTwoExp(sigma=1.0)
+        np.testing.assert_allclose(g.fwhm, 1.0 * sigma2fwhm)

--- a/lumispy/tests/test_component_registration.py
+++ b/lumispy/tests/test_component_registration.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019-2026 The LumiSpy developers
+#
+# This file is part of LumiSpy.
+#
+# LumiSpy is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the license, or
+# (at your option) any later version.
+#
+# LumiSpy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with LumiSpy. If not, see <https://www.gnu.org/licenses/#GPL>.
+
+import inspect
+from uuid import UUID
+
+import lumispy.components as lumispy_components
+import pytest
+from hyperspy.component import Component
+from hyperspy.extensions import ALL_EXTENSIONS
+
+
+def _public_component_classes():
+    """Return every component registered in lumispy.components.__all__."""
+    component_classes = []
+
+    for name in lumispy_components.__all__:
+        obj = getattr(lumispy_components, name)
+
+        assert inspect.isclass(obj), f"`{name}` is not a class."
+
+        assert issubclass(obj, Component), (
+            f"`{name}` is not a HyperSpy Component subclass."
+        )
+
+        component_classes.append(obj)
+
+    return component_classes
+
+
+def _registered_lumispy_components():
+    """
+    Return all LumiSpy components that are registered in HyperSpy and are loaded.
+    """
+    registered = {}
+    package_name = lumispy_components.__name__
+
+    for component_group in ("components1D", "components2D"):
+        for component_id, specification in ALL_EXTENSIONS.get(
+            component_group, {}
+        ).items():
+            module = specification["module"]
+
+            is_lumispy_component = module == package_name or module.startswith(
+                f"{package_name}."
+            )
+
+            if not is_lumispy_component:
+                continue
+
+            key = (module, specification["class"])
+
+            assert key not in registered, (
+                f"{specification['class']} is registered more than once in HyperSpy extensions."
+            )
+
+            registered[key] = (component_group, component_id)
+
+    return registered
+
+
+def test_component_registration():
+    public_components = _public_component_classes()
+
+    expected = {
+        (component_class.__module__, component_class.__name__)
+        for component_class in public_components
+    }
+
+    registered = _registered_lumispy_components()
+    registered_keys = set(registered.keys())
+
+    missing_registrations = expected - registered_keys
+    obsolete_registrations = registered_keys - expected
+
+    assert not missing_registrations, (
+        "These LumiSpy components are missing from "
+        "`hyperspy_extension.yaml`:\n"
+        + "\n".join(
+            f"  - {module}.{class_name}"
+            for module, class_name in sorted(missing_registrations)
+        )
+    )
+
+    assert not obsolete_registrations, (
+        "These components are registered in `hyperspy_extension.yaml` but "
+        "are not exported by `lumispy.components.__all__`:\n"
+        + "\n".join(
+            f"  - {module}.{class_name}"
+            for module, class_name in sorted(obsolete_registrations)
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "component_class",
+    _public_component_classes(),
+    ids=lambda component_class: component_class.__name__,
+)
+def test_component_uuid(component_class):
+    registered = _registered_lumispy_components()
+
+    component_key = (
+        component_class.__module__,
+        component_class.__name__,
+    )
+
+    _, registered_id = registered[component_key]
+
+    component = component_class()
+
+    assert component._id_name == registered_id
+    assert UUID(component._id_name).version == 4

--- a/upcoming_changes/262.new.rst
+++ b/upcoming_changes/262.new.rst
@@ -1,0 +1,1 @@
+First components for LumiSpy. :class:`~.components.convolved_gaussian_exponential.ConvGaussExp` and :class:`~.components.convolved_gaussian_two_exponential.ConvGaussTwoExp`.


### PR DESCRIPTION
### Description of the change
Added a the first component for lumispy a convolved gaussian exponential

### Progress of the PR
- [x] Change implemented (can be split into several points),
- [x] docstring updated (if appropriate),
- [x] update user guide (if appropriate),
- [x] added tests,
- [x] add a changelog entry in the `upcoming_changes` folder (see [`upcoming_changes/README.rst`](https://github.com/lumispy/lumispy/blob/main/upcoming_changes/README.rst)),
- [x] Check formatting of the changelog entry (and eventual user guide changes) in the `docs/readthedocs.org:lumispy` build of this PR (link in github checks),
- [x] ready for review.

### Minimal example of the bug fix or the new feature
```python
import lumispy as lum
m = s.create_model()
g1 = lum.components.ConvGaussExp()
m.append(g1)
m.fit()
```